### PR TITLE
refact: supabase auth migration #64

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,13 @@
       "Bash(git:*)",
       "Bash(.venv/Scripts/python.exe -m pytest tests/ -v)",
       "Bash(.venv/Scripts/python.exe -m pytest backend/tests/ -v)",
-      "Bash(.venv/Scripts/python.exe -m pytest backend/tests/ -v --tb=short)"
+      "Bash(.venv/Scripts/python.exe -m pytest backend/tests/ -v --tb=short)",
+      "Bash(grep -E \"\\\\.md$\")",
+      "Bash(npx tsc:*)",
+      "Bash(node_modules/.bin/tsc --noEmit)",
+      "Bash(ls node_modules/.bin/tsc*)",
+      "Bash(which node:*)",
+      "Bash(npm install:*)"
     ]
   }
 }

--- a/frontend/components/announcements/teacher-announcements.tsx
+++ b/frontend/components/announcements/teacher-announcements.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/auth-context";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -25,9 +26,8 @@ import {
 import {
   getNotices,
   getNoticeSettings,
-  Announcement,
   updateNoticeSettings,
-  type Notice,
+  type Announcement,
   type NoticeSettings,
 } from "@/lib/api";
 
@@ -75,38 +75,47 @@ const draftAnnouncements = [
 ];
 
 export function TeacherAnnouncements() {
+  const { user } = useAuth();
   const [activeTab, setActiveTab] = useState("published");
   const [notices, setNotices] = useState<Announcement[]>([]);
   const [settings, setSettings] = useState<NoticeSettings | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!user?.id) return;
     const load = async () => {
+      setError(null);
       try {
         const [noticesData, settingsData] = await Promise.all([
           getNotices(),
-          getNoticeSettings(),
+          getNoticeSettings(user.id),
         ]);
         setNotices(noticesData);
         setSettings(settingsData);
-      } catch {
-        // fallback to local demo data
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "데이터를 불러오지 못했습니다.");
       }
     };
     void load();
-  }, []);
+  }, [user?.id]);
 
   const handleSaveSettings = async () => {
-    if (!settings) return;
+    if (!settings || !user?.id) return;
     try {
-      const result = await updateNoticeSettings(settings);
+      const result = await updateNoticeSettings(user.id, settings);
       setSettings(result.settings);
-    } catch {
-      // keep silent in demo mode
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "설정 저장에 실패했습니다.");
     }
   };
 
   return (
     <div className="flex flex-col gap-5 p-4 pb-24">
+      {error && (
+        <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
       {/* 페이지 헤더 */}
       <div className="flex items-center justify-between">
         <div>

--- a/frontend/components/materials/teacher-materials.tsx
+++ b/frontend/components/materials/teacher-materials.tsx
@@ -26,34 +26,45 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
-  createAudioConvertTask,
-  getAnalysisReport,
-  getAudioConvertTask,
-  type AnalysisReport,
+  getCourses,
+  getAudio,
+  type Course,
   type AudioConvertTask,
 } from "@/lib/api";
 import { supabase } from "@/lib/supabase/client";
 
 export function TeacherMaterials() {
-  // TODO: 실제 환경에서는 백엔드 API를 호출하여 데이터를 설정해야 합니다.
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [selectedCourseId, setSelectedCourseId] = useState<string | null>(null);
   const [previewMaterials, setPreviewMaterials] = useState<any[]>([]);
   const [reviewMaterials, setReviewMaterials] = useState<any[]>([]);
   const [scripts, setScripts] = useState<any[]>([]);
 
   const [activeTab, setActiveTab] = useState("preview");
   const [audioTask, setAudioTask] = useState<AudioConvertTask | null>(null);
-  const [analysisReport, setAnalysisReport] = useState<AnalysisReport | null>(
-    null,
-  );
   const [isStartingConvert, setIsStartingConvert] = useState(false);
   const [isUploadingScript, setIsUploadingScript] = useState(false);
   const scriptInputRef = useRef<HTMLInputElement>(null);
   const audioInputRef = useRef<HTMLInputElement>(null);
 
-  // TODO: 실제 환경에서는 라우터 파라미터나 상태 관리에서 현재 강의 ID를 가져와야 합니다.
-  const courseId = "crs_001";
+  // Active courseId — use selected course if set, otherwise first from list
+  const courseId = selectedCourseId ?? courses[0]?.courseId ?? null;
+
+  // Load instructor's courses on mount
+  useEffect(() => {
+    const loadCourses = async () => {
+      try {
+        const res = await getCourses();
+        setCourses(res.courses ?? []);
+      } catch (err) {
+        console.error("강의 목록 로드 실패:", err);
+      }
+    };
+    void loadCourses();
+  }, []);
 
   useEffect(() => {
+    if (!courseId) return;
     const fetchMaterialsData = async () => {
       try {
         // 1. 예습 자료 (preview_guides) 조회
@@ -135,34 +146,37 @@ export function TeacherMaterials() {
     };
 
     void fetchMaterialsData();
+  }, [courseId]);
 
-    const loadReport = async () => {
-      try {
-        const report = await getAnalysisReport();
-        setAnalysisReport(report);
-      } catch {
-        // fallback to local demo
-      }
-    };
-    void loadReport();
-  }, []);
-
+  // Poll audio transcription status using the correct course-scoped endpoint
   useEffect(() => {
-    if (!audioTask || audioTask.status === "completed") {
+    if (!audioTask || !courseId || audioTask.status === "completed") {
       return;
     }
 
     const intervalId = window.setInterval(async () => {
       try {
-        const task = await getAudioConvertTask(audioTask.task_id);
-        setAudioTask(task);
+        const item = await getAudio(courseId, audioTask.task_id);
+        // Map AudioItem → AudioConvertTask shape used by the component
+        setAudioTask((prev) =>
+          prev
+            ? {
+                ...prev,
+                status: item.status === "COMPLETED" ? "completed" : "processing",
+                transcript_preview: item.transcriptPreview,
+              }
+            : prev,
+        );
+        if (item.status === "COMPLETED" || item.status === "FAILED") {
+          window.clearInterval(intervalId);
+        }
       } catch {
         window.clearInterval(intervalId);
       }
     }, 2000);
 
     return () => window.clearInterval(intervalId);
-  }, [audioTask]);
+  }, [audioTask, courseId]);
 
   const handleAudioUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -270,6 +284,30 @@ export function TeacherMaterials() {
         </Button>
       </div>
 
+      {/* 강의 선택 */}
+      {courses.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {courses.map((c) => (
+            <button
+              key={c.courseId}
+              onClick={() => setSelectedCourseId(c.courseId)}
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                courseId === c.courseId
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-muted text-muted-foreground hover:border-primary/50"
+              }`}
+            >
+              {c.courseName}
+            </button>
+          ))}
+        </div>
+      )}
+      {!courseId && courses.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          {"담당 강의가 없습니다. 먼저 강의를 생성해 주세요."}
+        </p>
+      )}
+
       {/* AI 분석 카드 */}
       <Card className="border-primary/20 bg-linear-to-br from-primary/5 to-primary/10">
         <CardContent className="p-4">
@@ -329,26 +367,18 @@ export function TeacherMaterials() {
         </CardContent>
       </Card>
 
-      {(audioTask || analysisReport) && (
+      {audioTask && (
         <Card className="border-border/40">
           <CardContent className="space-y-2 p-4">
-            {audioTask && (
-              <p className="text-sm text-muted-foreground">
-                {"음성 변환: "}
-                {audioTask.file_name}
-                {" · "}
-                {audioTask.progress}%{" ("}
-                {audioTask.status}
-                {")"}
-              </p>
-            )}
-            {analysisReport && (
-              <p className="text-sm text-muted-foreground">
-                {"분석 리포트: "}
-                {analysisReport.source_file}
-                {" · 논리 허점 "}
-                {analysisReport.logical_gaps}
-                {"개"}
+            <p className="text-sm text-muted-foreground">
+              {"음성 변환: "}
+              {audioTask.file_name}
+              {" · "}
+              {audioTask.status === "completed" ? "완료" : "처리 중"}
+            </p>
+            {audioTask.transcript_preview && (
+              <p className="text-xs text-muted-foreground line-clamp-2">
+                {audioTask.transcript_preview}
               </p>
             )}
           </CardContent>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -248,16 +248,7 @@ export type StudentMaterialItem = {
   createdAt: string;
 };
 
-export async function login(payload: { email: string; password: string }) {
-  return request<LoginResponse>("/api/auth/login", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
-}
-
-export async function getDashboardSummary() {
-  return request<DashboardSummary>("/api/dashboard/summary");
-}
+// login() removed — authentication is handled by Supabase SDK in auth-context.tsx
 
 export async function getNotices(courseId?: string) {
   if (!courseId) {
@@ -565,57 +556,56 @@ export async function syncLmsStudents(
   });
 }
 
-export async function getNoticeSettings() {
-  return request<NoticeSettings>("/api/notices/settings");
+// Notification settings — scoped to userId
+// Merges /api/users/{userId}/notifications/channels + preferences
+export async function getNoticeSettings(userId: string): Promise<NoticeSettings> {
+  const [channelsRes, prefsRes] = await Promise.all([
+    request<{ channels: string[] }>(`/api/users/${userId}/notifications/channels`),
+    request<{ preferences: Array<{ notificationType: string; enabled: boolean }> }>(
+      `/api/users/${userId}/notifications/preferences`,
+    ),
+  ]);
+  const quizPref = prefsRes.preferences?.find((p) => p.notificationType === "QUIZ");
+  return {
+    channels: channelsRes.channels ?? [],
+    deadline_hours_before: 24,
+    quiz_notifications: quizPref?.enabled ?? true,
+  };
 }
 
-export async function updateNoticeSettings(payload: NoticeSettings) {
-  return request<{ message: string; settings: NoticeSettings }>(
-    "/api/notices/settings",
-    {
-      method: "PUT",
-      body: JSON.stringify(payload),
-    },
-  );
-}
-
-export async function getLatestQuiz() {
-  return request<QuizLatest>("/api/quiz/latest");
-}
-
-export async function generateQuiz(payload: QuizGeneratePayload) {
-  return request<{ message: string; quiz: QuizLatest; difficulty: string }>(
-    "/api/quiz/generate",
-    {
-      method: "POST",
-      body: JSON.stringify(payload),
-    },
-  );
-}
-
-export async function createAudioConvertTask(payload: {
-  file_name: string;
-  estimated_minutes?: number;
-}) {
-  return request<AudioConvertTask>("/api/materials/audio-convert", {
-    method: "POST",
-    body: JSON.stringify(payload),
+export async function updateNoticeSettings(
+  userId: string,
+  payload: NoticeSettings,
+): Promise<{ message: string; settings: NoticeSettings }> {
+  await request(`/api/users/${userId}/notifications/channels`, {
+    method: "PUT",
+    body: JSON.stringify({ channels: payload.channels }),
   });
+  return { message: "저장되었습니다.", settings: payload };
 }
 
-export async function getAudioConvertTask(taskId: string) {
-  return request<AudioConvertTask>(`/api/materials/audio-convert/${taskId}`);
+// Audio — course-scoped (replaces old /api/materials/audio-convert)
+export type AudioItem = {
+  audioId: string;
+  courseId: string;
+  fileName: string;
+  status: string; // PENDING | PROCESSING | COMPLETED | FAILED
+  transcriptPreview: string | null;
+  createdAt: string;
+};
+
+export async function getAudio(courseId: string, audioId: string): Promise<AudioItem> {
+  return request<AudioItem>(`/api/courses/${courseId}/audios/${audioId}`);
 }
 
-export async function getAnalysisReport() {
-  return Promise.resolve<AnalysisReport>({
-    source_file: "대기 중인 파일",
-    logical_gaps: 0,
-    missing_terms: [],
-    missing_prerequisites: [],
-    suggestions: ["분석 API는 getScriptAnalysis()로 연결해야 합니다."],
-  });
-}
+// createAudioConvertTask / getAudioConvertTask: removed (wrong endpoints).
+// Use direct fetch with FormData for upload (see teacher-materials.tsx),
+// then poll with getAudio(courseId, audioId).
+
+// getLatestQuiz / generateQuiz: removed (endpoints do not exist in backend).
+// Use getCourseQuizzes(courseId) and createQuiz(courseId, payload).
+
+// getAnalysisReport: removed (no generic endpoint). Use getScriptAnalysis(courseId, scriptId).
 
 // User Profile APIs
 export async function getUserProfile(userId: string): Promise<UserProfile> {


### PR DESCRIPTION

## 🚀 변경 사항

`frontend/lib/api.ts`

login() → /api/auth/login 제거 (이제 인증은 Supabase가 직접 처리함)

getDashboardSummary() → /api/dashboard/summary 제거 (아무도 호출하지 않는 데드 코드)

getLatestQuiz(), generateQuiz() 제거 → 잘못된 경로 (호출부 없음)

createAudioConvertTask(), getAudioConvertTask() 제거 → 잘못된 경로

getAnalysisReport() 제거 → 하드코딩된 모의(mock) 데이터를 반환하고 있었음

getNoticeSettings(userId) 수정 → 이제 /api/users/{userId}/notifications/channels 및 /preferences를 병합하여 호출함

updateNoticeSettings(userId, payload) 수정 → 이제 /api/users/{userId}/notifications/channels를 호출함

AudioItem 타입 및 getAudio(courseId, audioId) 추가 → 올바른 엔드포인트인 /api/courses/{courseId}/audios/{audioId} 연동 완료

`frontend/components/announcements/teacher-announcements.tsx`

user.id를 가져오기 위해 useAuth() 추가

getNoticeSettings() → getNoticeSettings(user.id)로 파라미터 전달 수정

updateNoticeSettings(settings) → updateNoticeSettings(user.id, settings)로 파라미터 전달 수정

조용한 실패(Silent catch) 제거 — 이제 API 실패 시 에러가 화면에 정상적으로 표시됨

사용하지 않는 Notice 타입 임포트 제거

`frontend/components/materials/teacher-materials.tsx`

하드코딩된 const courseId = "crs_001" 제거 — getCourses() 로직 추가 및 강의 선택(Course Selector) UI로 교체

courseId 동적 할당: 첫 번째 강의가 자동 선택되며, 사용자가 알약(pill) 형태의 버튼을 클릭하여 강의를 전환할 수 있음

오디오 폴링 로직 교체: getAudioConvertTask(audioTask.task_id) → getAudio(courseId, audioTask.task_id)로 변경하고 컴포넌트 규격에 맞게 상태값 매핑 적용

데이터 로딩 useEffect 개선: courseId 가드 추가(null일 때 불필요한 호출 방지) 및 강의가 변경될 때마다 데이터를 다시 불러오도록 수정

낡은 getAnalysisReport 화면 표시 로직 제거 — 실제 오디오 변환 응답 데이터에서 추출한 '스크립트 미리보기(transcript preview)'로 UI 교체

사용하지 않는 임포트 일괄 제거 (createAudioConvertTask, getAnalysisReport, AnalysisReport)

---


## 이슈 연결
<!--
PR merge 시 이슈가 자동으로 닫히도록 설정합니다.
-->
Closes #64 

---

## 📸 스크린샷
<!--
필수 항목입니다.
변경 전 / 변경 후 또는 데스크탑 / 모바일 스크린샷을 첨부합니다.
GIF도 가능하며, 인터랙션이 있는 경우 우선 첨부합니다.
-->

---

## 🧪 체크리스트
<!--
PR 생성 전 반드시 확인합니다.
-->
- [ ] 스크린샷 또는 GIF 첨부
- [ ] 로컬 환경에서 정상 작동 확인
- [ ] 주요 기능 테스트 완료
- [ ] 관련 없는 파일 변경 없음

---

## 참고 사항
<!--
리뷰 시 참고할 맥락이나 추후 개선 포인트를 작성합니다.
-->
