### PR TITLE
feat: UX 완성 안정화 구현

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,6 +6,8 @@ class Settings(BaseSettings):
     SUPABASE_KEY: str
     SUPABASE_JWT_SECRET: str
     SUPABASE_SERVICE_KEY: str = ""   # auth.admin 작업용 (탈퇴 계정 영구 삭제)
+    SUPABASE_JWKS_URL: str = ""      # 커스텀 JWKS URI (미설정 시 자동 생성)
+    SUPABASE_JWT_ISSUER: str = ""    # 커스텀 JWT issuer (미설정 시 자동 생성)
     GOOGLE_API_KEY: str
     WHISPER_MODEL_SIZE: str = "base"
 

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -8,6 +8,7 @@
 import logging
 import smtplib
 from datetime import datetime, timedelta, timezone
+from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 import httpx
@@ -85,6 +86,46 @@ def _send_in_app(user_id: str, title: str, body: str, reminder: dict) -> None:
     }).execute()
 
 
+def _build_email_html(title: str, body: str) -> str:
+    """마감 알림 HTML 이메일 템플릿."""
+    lines = body.replace("\n", "<br>")
+    return f"""<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:'Apple SD Gothic Neo',Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:32px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0"
+             style="background:#ffffff;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,.08);overflow:hidden;max-width:560px;width:100%;">
+        <!-- 헤더 -->
+        <tr>
+          <td style="background:#6366f1;padding:24px 32px;">
+            <p style="margin:0;color:#ffffff;font-size:20px;font-weight:700;">FeedA</p>
+            <p style="margin:4px 0 0;color:#c7d2fe;font-size:13px;">강의 지원 플랫폼</p>
+          </td>
+        </tr>
+        <!-- 본문 -->
+        <tr>
+          <td style="padding:32px;">
+            <h2 style="margin:0 0 16px;font-size:18px;color:#1e1b4b;">{title}</h2>
+            <p style="margin:0;font-size:14px;line-height:1.7;color:#374151;">{lines}</p>
+          </td>
+        </tr>
+        <!-- 푸터 -->
+        <tr>
+          <td style="background:#f9fafb;padding:16px 32px;border-top:1px solid #e5e7eb;">
+            <p style="margin:0;font-size:12px;color:#9ca3af;">
+              이 메일은 FeedA 플랫폼에서 자동 발송되었습니다. 수신을 원치 않으시면 알림 설정을 변경해 주세요.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>"""
+
+
 def _send_email(user_id: str, title: str, body: str, settings) -> None:
     if not settings.SMTP_HOST:
         logger.debug("SMTP 미설정 — 이메일 발송 스킵 user_id=%s", user_id)
@@ -102,10 +143,16 @@ def _send_email(user_id: str, title: str, body: str, settings) -> None:
     if not profile.data or not profile.data.get("email"):
         return
 
-    msg = MIMEText(body, "plain", "utf-8")
+    recipient = profile.data["email"]
+    sender = settings.SMTP_FROM or settings.SMTP_USER
+
+    msg = MIMEMultipart("alternative")
     msg["Subject"] = f"[FeedA] {title}"
-    msg["From"] = settings.SMTP_FROM or settings.SMTP_USER
-    msg["To"] = profile.data["email"]
+    msg["From"] = sender
+    msg["To"] = recipient
+
+    msg.attach(MIMEText(body, "plain", "utf-8"))
+    msg.attach(MIMEText(_build_email_html(title, body), "html", "utf-8"))
 
     with smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT) as server:
         server.starttls()

--- a/backend/tests/test_ai_simulation.py
+++ b/backend/tests/test_ai_simulation.py
@@ -1,0 +1,244 @@
+"""3-C. AI 시뮬레이션 파이프라인 상태 전이 테스트.
+
+커버리지:
+  - _run_assessment_generation : pending → processing → completed / failed
+  - _run_answer_generation     : pending → processing → completed / failed
+  - _run_grading               : pending → processing → completed / failed
+"""
+from unittest.mock import MagicMock, patch
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 공통 헬퍼
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_sb_for_assessment(questions=None):
+    """assessment + context 조회를 지원하는 Supabase 목."""
+    mock_sb = MagicMock()
+
+    # ai_sim_contexts 조회 (maybe_single)
+    context_row = MagicMock()
+    context_row.data = {"id": "ctx-001", "script_ids": ["script-001"]}
+
+    # scripts 조회
+    script_row = MagicMock()
+    script_row.data = {"id": "script-001", "content_path": "path/file.pdf", "mime_type": "application/pdf", "title": "테스트"}
+
+    # 체인 구성: table → select → eq → maybe_single → execute
+    def table_dispatch(name):
+        t = MagicMock()
+        sel = MagicMock()
+        sel.eq.return_value.maybe_single.return_value.execute.return_value = (
+            context_row if "context" in name else script_row
+        )
+        sel.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value = script_row
+        sel.eq.return_value.in_.return_value.execute.return_value = MagicMock(data=[{"id": "script-001"}])
+        sel.eq.return_value.execute.return_value = MagicMock(data=[])
+        t.select.return_value = sel
+        t.update.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        return t
+
+    mock_sb.table.side_effect = table_dispatch
+    mock_sb.storage.from_.return_value.download.return_value = b"fake pdf content"
+    return mock_sb
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5-2. _run_assessment_generation 상태 전이
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_assessment_generation_completed():
+    """AI 호출 성공 → ai_sim_assessments status=completed 로 업데이트."""
+    updated_status: list[str] = []
+
+    # supabase.table(...).update({...}).eq(...).execute() 체인을 단일 mock으로 처리
+    mock_sb = MagicMock()
+
+    def capture_update(payload: dict):
+        updated_status.append(payload.get("status", "?"))
+        chain = MagicMock()
+        chain.eq.return_value.execute.return_value = MagicMock(data=[])
+        return chain
+
+    mock_sb.table.return_value.update.side_effect = capture_update
+
+    fake_questions = [{"id": "q1", "type": "CONCEPT", "content": "질문1"}]
+
+    with (
+        patch("app.routers.ai_simulation.supabase", mock_sb),
+        patch("app.routers.ai_simulation.mark_processing", MagicMock()),
+        patch("app.routers.ai_simulation.mark_failed", MagicMock()),
+        # _get_context_text를 직접 패치해서 DB/Storage 체인 우회
+        patch("app.routers.ai_simulation._get_context_text", return_value="스크립트 내용"),
+        patch("app.core.ai.call_sonnet_json", return_value={"questions": fake_questions}),
+    ):
+        from app.routers.ai_simulation import _run_assessment_generation
+        _run_assessment_generation(
+            "assess-001", "course-001", "ctx-001",
+            ["CONCEPT", "APPLICATION"], 5,
+        )
+
+    assert "completed" in updated_status, f"completed 전이 없음: {updated_status}"
+
+
+def test_assessment_generation_failed_on_empty_script():
+    """빈 스크립트 텍스트 → mark_failed 호출."""
+    failed_ids: list[str] = []
+
+    with (
+        patch("app.routers.ai_simulation.mark_processing", MagicMock()),
+        patch("app.routers.ai_simulation.mark_failed",
+              lambda table, rid, msg: failed_ids.append(rid)),
+        patch("app.routers.ai_simulation._get_context_text", return_value=""),
+    ):
+        from app.routers.ai_simulation import _run_assessment_generation
+        _run_assessment_generation(
+            "assess-fail", "course-001", "ctx-001", ["CONCEPT"], 3,
+        )
+
+    assert "assess-fail" in failed_ids, "빈 스크립트에 failed 전이 없음"
+
+
+def test_assessment_generation_failed_on_ai_error():
+    """AI 호출 예외 → mark_failed 호출."""
+    failed_ids: list[str] = []
+
+    with (
+        patch("app.routers.ai_simulation.mark_processing", MagicMock()),
+        patch("app.routers.ai_simulation.mark_failed",
+              lambda table, rid, msg: failed_ids.append(rid)),
+        patch("app.routers.ai_simulation._get_context_text", return_value="스크립트"),
+        patch("app.core.ai.call_sonnet_json", side_effect=RuntimeError("AI 오류")),
+    ):
+        from app.routers.ai_simulation import _run_assessment_generation
+        _run_assessment_generation(
+            "assess-ai-err", "course-001", "ctx-001", ["CONCEPT"], 3,
+        )
+
+    assert "assess-ai-err" in failed_ids, "AI 오류에 failed 전이 없음"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5-3. _run_answer_generation 상태 전이
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_answer_generation_completed():
+    """문항 있음 + 스크립트 있음 → ai_sim_answers status=completed."""
+    updated_status: list[str] = []
+
+    def capture_update(payload: dict):
+        updated_status.append(payload.get("status", "?"))
+        chain = MagicMock()
+        chain.eq.return_value.execute.return_value = MagicMock(data=[])
+        return chain
+
+    mock_sb = MagicMock()
+    # ai_sim_assessments 조회 (questions 반환)
+    mock_sb.table.return_value.select.return_value.eq.return_value\
+        .maybe_single.return_value.execute.return_value = MagicMock(
+        data={"questions": [{"id": "q1", "content": "질문"}]}
+    )
+    mock_sb.table.return_value.update.side_effect = capture_update
+
+    with (
+        patch("app.routers.ai_simulation.supabase", mock_sb),
+        patch("app.routers.ai_simulation.mark_processing", MagicMock()),
+        patch("app.routers.ai_simulation.mark_failed", MagicMock()),
+        patch("app.routers.ai_simulation._get_context_text", return_value="스크립트"),
+        patch("app.core.ai.call_haiku_json",
+              return_value={"answers": [{"questionId": "q1", "answer": "답변1"}]}),
+    ):
+        from app.routers.ai_simulation import _run_answer_generation
+        _run_answer_generation("ans-001", "assess-001", "course-001", "ctx-001")
+
+    assert "completed" in updated_status, f"completed 전이 없음: {updated_status}"
+
+
+def test_answer_generation_failed_on_empty_questions():
+    """문항 없음 → mark_failed 호출."""
+    failed_ids: list[str] = []
+
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.select.return_value.eq.return_value\
+        .maybe_single.return_value.execute.return_value = MagicMock(data={"questions": []})
+
+    with (
+        patch("app.routers.ai_simulation.supabase", mock_sb),
+        patch("app.routers.ai_simulation.mark_processing", MagicMock()),
+        patch("app.routers.ai_simulation.mark_failed",
+              lambda table, rid, msg: failed_ids.append(rid)),
+        patch("app.routers.ai_simulation._get_context_text", return_value="스크립트"),
+    ):
+        from app.routers.ai_simulation import _run_answer_generation
+        _run_answer_generation("ans-fail", "assess-001", "course-001", "ctx-001")
+
+    assert "ans-fail" in failed_ids, "빈 문항에 failed 전이 없음"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5-4. _run_grading 상태 전이
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_grading_completed():
+    """문항 + 답변 있음 → ai_sim_grades status=completed."""
+    updated_status: list[str] = []
+
+    def capture_update(payload: dict):
+        updated_status.append(payload.get("status", "?"))
+        chain = MagicMock()
+        chain.eq.return_value.execute.return_value = MagicMock(data=[])
+        return chain
+
+    mock_sb = MagicMock()
+
+    call_count = 0
+    def maybe_single_execute():
+        nonlocal call_count
+        call_count += 1
+        # 첫 번째: 문항 조회, 두 번째: 답변 조회
+        if call_count == 1:
+            return MagicMock(data={"questions": [{"id": "q1", "content": "질문"}]})
+        return MagicMock(data={"answers": [{"questionId": "q1", "answer": "답변"}]})
+
+    mock_sb.table.return_value.select.return_value.eq.return_value\
+        .maybe_single.return_value.execute.side_effect = lambda: maybe_single_execute()
+    mock_sb.table.return_value.update.side_effect = capture_update
+
+    fake_result = {
+        "total_score": 85.0,
+        "grades": [{"questionId": "q1", "score": 85}],
+        "strengths": ["개념 이해"],
+        "weaknesses": [],
+    }
+
+    with (
+        patch("app.routers.ai_simulation.supabase", mock_sb),
+        patch("app.routers.ai_simulation.mark_processing", MagicMock()),
+        patch("app.routers.ai_simulation.mark_failed", MagicMock()),
+        patch("app.core.ai.call_sonnet_json", return_value=fake_result),
+    ):
+        from app.routers.ai_simulation import _run_grading
+        _run_grading("grade-001", "assess-001")
+
+    assert "completed" in updated_status, f"completed 전이 없음: {updated_status}"
+
+
+def test_grading_failed_on_missing_data():
+    """문항 또는 답변 없음 → mark_failed 호출."""
+    failed_ids: list[str] = []
+
+    mock_sb = MagicMock()
+    # 두 조회 모두 빈 결과
+    mock_sb.table.return_value.select.return_value.eq.return_value\
+        .maybe_single.return_value.execute.return_value = MagicMock(data={})
+
+    with (
+        patch("app.routers.ai_simulation.supabase", mock_sb),
+        patch("app.routers.ai_simulation.mark_processing", MagicMock()),
+        patch("app.routers.ai_simulation.mark_failed",
+              lambda table, rid, msg: failed_ids.append(rid)),
+    ):
+        from app.routers.ai_simulation import _run_grading
+        _run_grading("grade-fail", "assess-001")
+
+    assert "grade-fail" in failed_ids, "빈 데이터에 failed 전이 없음"

--- a/backend/tests/test_scheduler_smtp.py
+++ b/backend/tests/test_scheduler_smtp.py
@@ -1,0 +1,235 @@
+"""3-C. 스케줄러 + SMTP 이메일 발송 테스트.
+
+커버리지:
+  - _send_email  : SMTP 미설정 시 스킵, 설정 시 smtplib 호출
+  - _send_in_app : notifications 테이블에 INSERT
+  - send_pending_reminders : PENDING 리마인더 조회 → _dispatch_reminder → SENT 업데이트
+  - _build_email_html : HTML 템플릿에 제목·본문 포함 여부
+
+NOTE: conftest.py의 session-scoped app_client fixture가
+  `patch.object(scheduler_module, "send_pending_reminders", MagicMock())` 를 수행하므로
+  테스트 파일 임포트 시점(컬렉션 단계 — fixture 활성화 전)에 실제 함수를 캡처해 둔다.
+"""
+import smtplib
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+# ── 모듈 임포트 시점에 실제 함수 레퍼런스 보관 ──────────────────────────────────
+# pytest 컬렉션 단계(session fixture 활성화 전)에 실행되므로 아직 패치되지 않은 상태.
+import app.core.scheduler as _sched_mod
+_real_send_pending_reminders = _sched_mod.send_pending_reminders
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _build_email_html
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_build_email_html_contains_title_and_body():
+    from app.core.scheduler import _build_email_html
+    html = _build_email_html("퀴즈 마감 알림", "마감이 2시간 후입니다.")
+    assert "퀴즈 마감 알림" in html
+    assert "마감이 2시간 후입니다." in html
+    assert "<!DOCTYPE html>" in html
+
+
+def test_build_email_html_newlines_converted_to_br():
+    from app.core.scheduler import _build_email_html
+    html = _build_email_html("제목", "줄1\n줄2")
+    assert "<br>" in html
+    # 원문 \n은 HTML 엔티티로 존재하지 않아야 함 (br로 치환됨)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _send_email — SMTP 미설정 시 스킵
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_send_email_skips_when_no_smtp_host():
+    """SMTP_HOST 미설정이면 smtplib.SMTP가 호출되지 않아야 한다."""
+    fake_settings = SimpleNamespace(SMTP_HOST="", SMTP_PORT=587, SMTP_USER="", SMTP_PASSWORD="", SMTP_FROM="")
+
+    with patch("smtplib.SMTP") as mock_smtp:
+        from app.core.scheduler import _send_email
+        _send_email("user-001", "제목", "내용", fake_settings)
+
+    mock_smtp.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _send_email — SMTP 설정 시 실제 발송
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_send_email_calls_smtp_when_configured():
+    """SMTP_HOST 설정 시 smtplib.SMTP.__enter__ → starttls → login → send_message 순서."""
+    fake_settings = SimpleNamespace(
+        SMTP_HOST="smtp.example.com",
+        SMTP_PORT=587,
+        SMTP_USER="user@example.com",
+        SMTP_PASSWORD="secret",
+        SMTP_FROM="no-reply@example.com",
+    )
+
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.select.return_value.eq.return_value\
+        .maybe_single.return_value.execute.return_value = MagicMock(
+        data={"email": "student@example.com"}
+    )
+
+    mock_server = MagicMock()
+    mock_smtp_cls = MagicMock()
+    mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+    mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("app.core.scheduler.smtplib.SMTP", mock_smtp_cls),
+        patch("app.database.supabase", mock_sb),
+    ):
+        from app.core.scheduler import _send_email
+        _send_email("user-001", "퀴즈 마감 알림", "2시간 후 마감입니다.", fake_settings)
+
+    mock_server.starttls.assert_called_once()
+    mock_server.login.assert_called_once_with("user@example.com", "secret")
+    mock_server.send_message.assert_called_once()
+
+
+def test_send_email_skips_if_no_profile_email():
+    """profiles.email이 없으면 smtplib.SMTP가 호출되지 않아야 한다."""
+    fake_settings = SimpleNamespace(
+        SMTP_HOST="smtp.example.com",
+        SMTP_PORT=587,
+        SMTP_USER="u",
+        SMTP_PASSWORD="p",
+        SMTP_FROM="",
+    )
+
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.select.return_value.eq.return_value\
+        .maybe_single.return_value.execute.return_value = MagicMock(data=None)
+
+    with (
+        patch("smtplib.SMTP") as mock_smtp,
+        patch("app.database.supabase", mock_sb),
+    ):
+        from app.core.scheduler import _send_email
+        _send_email("user-no-email", "제목", "내용", fake_settings)
+
+    mock_smtp.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _send_in_app
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_send_in_app_inserts_notification():
+    """IN_APP 채널 발송 시 notifications 테이블에 INSERT 호출."""
+    mock_sb = MagicMock()
+    insert_result = MagicMock()
+    insert_result.data = [{"id": "noti-001"}]
+    mock_sb.table.return_value.insert.return_value.execute.return_value = insert_result
+
+    reminder = {
+        "deadline_id": "dl-001",
+        "deadlines": {"course_id": "course-001"},
+    }
+
+    with patch("app.database.supabase", mock_sb):
+        from app.core.scheduler import _send_in_app
+        _send_in_app("user-001", "마감 알림", "1시간 후", reminder)
+
+    mock_sb.table.assert_called_with("notifications")
+    mock_sb.table.return_value.insert.assert_called_once()
+    inserted = mock_sb.table.return_value.insert.call_args[0][0]
+    assert inserted["user_id"] == "user-001"
+    assert inserted["title"] == "마감 알림"
+    assert inserted["is_read"] is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# send_pending_reminders 통합 흐름
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_send_pending_reminders_marks_sent():
+    """PENDING 리마인더 → _dispatch_reminder 호출 → status=SENT 업데이트."""
+    dispatched: list[dict] = []
+
+    def fake_dispatch(reminder, settings):
+        dispatched.append(reminder)
+
+    mock_sb = MagicMock()
+
+    # PENDING 리마인더 2건 반환
+    pending_data = [
+        {
+            "id": "r-001", "deadline_id": "dl-001", "user_id": "u-001",
+            "channel": "IN_APP", "hours_before": 2,
+            "deadlines": {"title": "퀴즈 마감", "due_at": "2026-05-01T09:00:00Z", "course_id": "c-001"},
+        },
+        {
+            "id": "r-002", "deadline_id": "dl-002", "user_id": "u-002",
+            "channel": "EMAIL", "hours_before": 24,
+            "deadlines": {"title": "과제 마감", "due_at": "2026-05-02T12:00:00Z", "course_id": "c-001"},
+        },
+    ]
+    pending_result = MagicMock()
+    pending_result.data = pending_data
+
+    # select → eq → lte → limit → execute 체인
+    mock_sb.table.return_value.select.return_value.eq.return_value\
+        .lte.return_value.limit.return_value.execute.return_value = pending_result
+
+    # update → eq → execute
+    mock_sb.table.return_value.update.return_value.eq.return_value\
+        .execute.return_value = MagicMock(data=[])
+
+    fake_settings = SimpleNamespace(
+        SMTP_HOST="", SMTP_PORT=587, SMTP_USER="", SMTP_PASSWORD="", SMTP_FROM="",
+        KAKAO_ACCESS_TOKEN="",
+    )
+
+    with (
+        patch("app.database.supabase", mock_sb),
+        patch("app.core.config.settings", fake_settings),
+        patch("app.core.scheduler._dispatch_reminder", fake_dispatch),
+    ):
+        _real_send_pending_reminders()
+
+    assert len(dispatched) == 2, f"dispatch 호출 횟수 불일치: {len(dispatched)}"
+
+    # SENT 업데이트가 2회 호출되었는지 확인
+    update_calls = mock_sb.table.return_value.update.call_args_list
+    sent_updates = [c for c in update_calls if c[0][0].get("status") == "SENT"]
+    assert len(sent_updates) == 2, f"SENT 업데이트 횟수 불일치: {len(sent_updates)}"
+
+
+def test_send_pending_reminders_marks_failed_on_dispatch_error():
+    """_dispatch_reminder 예외 시 status=FAILED 업데이트."""
+    mock_sb = MagicMock()
+
+    pending_data = [{
+        "id": "r-err", "deadline_id": "dl-001", "user_id": "u-001",
+        "channel": "IN_APP", "hours_before": 2,
+        "deadlines": {"title": "제목", "due_at": "2026-05-01T09:00:00Z", "course_id": "c-001"},
+    }]
+    pending_result = MagicMock()
+    pending_result.data = pending_data
+
+    mock_sb.table.return_value.select.return_value.eq.return_value\
+        .lte.return_value.limit.return_value.execute.return_value = pending_result
+    mock_sb.table.return_value.update.return_value.eq.return_value\
+        .execute.return_value = MagicMock(data=[])
+
+    fake_settings = SimpleNamespace(
+        SMTP_HOST="", SMTP_PORT=587, SMTP_USER="", SMTP_PASSWORD="", SMTP_FROM="",
+        KAKAO_ACCESS_TOKEN="",
+    )
+
+    with (
+        patch("app.database.supabase", mock_sb),
+        patch("app.core.config.settings", fake_settings),
+        patch("app.core.scheduler._dispatch_reminder",
+              side_effect=RuntimeError("발송 실패")),
+    ):
+        _real_send_pending_reminders()
+
+    update_calls = mock_sb.table.return_value.update.call_args_list
+    failed_updates = [c for c in update_calls if c[0][0].get("status") == "FAILED"]
+    assert len(failed_updates) == 1, f"FAILED 업데이트 없음: {update_calls}"

--- a/frontend/app/deadlines/page.tsx
+++ b/frontend/app/deadlines/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { AppShell } from "@/components/layout/app-shell";
+import { useAuth } from "@/contexts/auth-context";
+import { getReminders, dismissReminder, type Reminder } from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Spinner } from "@/components/ui/spinner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Calendar, Clock, X, AlertCircle, Settings } from "lucide-react";
+
+function getReminderStyle(status: Reminder["status"]) {
+  switch (status) {
+    case "pending":
+      return {
+        bg: "bg-amber-500/10",
+        icon: "text-amber-500",
+        badge: "secondary" as const,
+      };
+    case "sent":
+      return {
+        bg: "bg-blue-500/10",
+        icon: "text-blue-500",
+        badge: "default" as const,
+      };
+    case "dismissed":
+      return {
+        bg: "bg-muted",
+        icon: "text-muted-foreground",
+        badge: "outline" as const,
+      };
+  }
+}
+
+function getStatusLabel(status: Reminder["status"]) {
+  switch (status) {
+    case "pending":
+      return "대기 중";
+    case "sent":
+      return "발송됨";
+    case "dismissed":
+      return "해제됨";
+  }
+}
+
+export default function DeadlinesPage() {
+  const { user, isLoading: isAuthLoading, isHydrated } = useAuth();
+  const router = useRouter();
+  const [reminders, setReminders] = useState<Reminder[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dismissingId, setDismissingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isHydrated && !isAuthLoading && !user) {
+      router.push("/login");
+    }
+  }, [user, isAuthLoading, isHydrated, router]);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await getReminders(user.id);
+        setReminders(res.reminders);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "마감일 정보를 불러오지 못했습니다.",
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    void load();
+  }, [user?.id]);
+
+  const handleDismiss = async (reminderId: string) => {
+    if (!user?.id) return;
+    setDismissingId(reminderId);
+    try {
+      await dismissReminder(user.id, reminderId);
+      setReminders((prev) =>
+        prev.map((r) =>
+          r.reminderId === reminderId ? { ...r, status: "dismissed" } : r,
+        ),
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "알림 해제에 실패했습니다.",
+      );
+    } finally {
+      setDismissingId(null);
+    }
+  };
+
+  if (!isHydrated || isAuthLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <Spinner className="size-8 text-primary" />
+      </div>
+    );
+  }
+
+  if (!user) return null;
+
+  const pendingReminders = reminders.filter((r) => r.status === "pending");
+  const otherReminders = reminders.filter((r) => r.status !== "pending");
+
+  return (
+    <AppShell>
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-5 p-4 pb-24">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold text-foreground">{"마감일"}</h1>
+            <p className="text-sm text-muted-foreground">
+              {pendingReminders.length > 0
+                ? `대기 중인 알림 ${pendingReminders.length}개`
+                : "예정된 마감일이 없습니다"}
+            </p>
+          </div>
+          <Button variant="outline" size="sm" className="gap-2" asChild>
+            <Link href="/settings/reminders">
+              <Settings className="size-4" />
+              {"알림 설정"}
+            </Link>
+          </Button>
+        </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertCircle className="size-4" />
+            <AlertTitle>{"오류"}</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {isLoading ? (
+          <div className="flex justify-center py-20">
+            <Spinner className="size-8 text-primary" />
+          </div>
+        ) : reminders.length === 0 ? (
+          <Card className="border-dashed">
+            <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+              <Calendar className="size-12 text-muted-foreground/50" />
+              <p className="text-sm text-muted-foreground">
+                {"마감일 알림이 없습니다."}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {"강의별 마감일이 등록되면 여기에 표시됩니다."}
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            {pendingReminders.length > 0 && (
+              <section>
+                <h2 className="mb-3 text-sm font-semibold text-foreground">
+                  {"대기 중인 알림"}
+                </h2>
+                <div className="flex flex-col gap-2">
+                  {pendingReminders.map((reminder) => {
+                    const style = getReminderStyle(reminder.status);
+                    return (
+                      <Card key={reminder.reminderId} className="border-border/40">
+                        <CardContent className="flex items-start justify-between p-4">
+                          <div className="flex items-start gap-3">
+                            <div
+                              className={`flex size-10 shrink-0 items-center justify-center rounded-xl ${style.bg}`}
+                            >
+                              <Clock className={`size-5 ${style.icon}`} />
+                            </div>
+                            <div>
+                              <div className="flex items-center gap-2 flex-wrap">
+                                <p className="text-sm font-medium text-foreground">
+                                  {reminder.title}
+                                </p>
+                                <Badge
+                                  variant={style.badge}
+                                  className="h-4 px-1.5 text-[10px]"
+                                >
+                                  {getStatusLabel(reminder.status)}
+                                </Badge>
+                              </div>
+                              {reminder.description && (
+                                <p className="mt-1 text-sm text-muted-foreground">
+                                  {reminder.description}
+                                </p>
+                              )}
+                              <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+                                <Calendar className="size-3" />
+                                <span>
+                                  {new Date(reminder.dueDate).toLocaleString(
+                                    "ko-KR",
+                                  )}
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-8 shrink-0"
+                            disabled={dismissingId === reminder.reminderId}
+                            onClick={() => handleDismiss(reminder.reminderId)}
+                          >
+                            {dismissingId === reminder.reminderId ? (
+                              <Spinner className="size-3" />
+                            ) : (
+                              <X className="size-4" />
+                            )}
+                          </Button>
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
+
+            {otherReminders.length > 0 && (
+              <section>
+                <h2 className="mb-3 text-sm font-semibold text-muted-foreground">
+                  {"이전 알림"}
+                </h2>
+                <div className="flex flex-col gap-2">
+                  {otherReminders.map((reminder) => {
+                    const style = getReminderStyle(reminder.status);
+                    return (
+                      <Card
+                        key={reminder.reminderId}
+                        className="border-border/40 opacity-60"
+                      >
+                        <CardContent className="flex items-start gap-3 p-4">
+                          <div
+                            className={`flex size-10 shrink-0 items-center justify-center rounded-xl ${style.bg}`}
+                          >
+                            <Clock className={`size-5 ${style.icon}`} />
+                          </div>
+                          <div>
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <p className="text-sm font-medium text-foreground">
+                                {reminder.title}
+                              </p>
+                              <Badge
+                                variant={style.badge}
+                                className="h-4 px-1.5 text-[10px]"
+                              >
+                                {getStatusLabel(reminder.status)}
+                              </Badge>
+                            </div>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {new Date(reminder.dueDate).toLocaleString(
+                                "ko-KR",
+                              )}
+                            </p>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
+          </>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/app/notifications/page.tsx
+++ b/frontend/app/notifications/page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { AppShell } from "@/components/layout/app-shell";
+import { useAuth } from "@/contexts/auth-context";
+import {
+  getNotifications,
+  markNotificationAsRead,
+  type Notification,
+} from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Spinner } from "@/components/ui/spinner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Bell, CheckCheck, AlertCircle } from "lucide-react";
+
+export default function NotificationsPage() {
+  const { user, isLoading: isAuthLoading, isHydrated } = useAuth();
+  const router = useRouter();
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [markingId, setMarkingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isHydrated && !isAuthLoading && !user) {
+      router.push("/login");
+    }
+  }, [user, isAuthLoading, isHydrated, router]);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await getNotifications(user.id);
+        setNotifications(res.notifications);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "알림을 불러오지 못했습니다.",
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    void load();
+  }, [user?.id]);
+
+  const handleMarkAsRead = async (notificationId: string) => {
+    if (!user?.id) return;
+    setMarkingId(notificationId);
+    try {
+      await markNotificationAsRead(user.id, notificationId);
+      setNotifications((prev) =>
+        prev.map((n) =>
+          n.notificationId === notificationId ? { ...n, read: true } : n,
+        ),
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "읽음 처리에 실패했습니다.",
+      );
+    } finally {
+      setMarkingId(null);
+    }
+  };
+
+  const handleMarkAllAsRead = async () => {
+    if (!user?.id) return;
+    const unread = notifications.filter((n) => !n.read);
+    for (const n of unread) {
+      await handleMarkAsRead(n.notificationId);
+    }
+  };
+
+  if (!isHydrated || isAuthLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <Spinner className="size-8 text-primary" />
+      </div>
+    );
+  }
+
+  if (!user) return null;
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  return (
+    <AppShell>
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-5 p-4 pb-24">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold text-foreground">{"알림"}</h1>
+            <p className="text-sm text-muted-foreground">
+              {unreadCount > 0
+                ? `읽지 않은 알림 ${unreadCount}개`
+                : "모든 알림을 읽었습니다"}
+            </p>
+          </div>
+          {unreadCount > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={handleMarkAllAsRead}
+            >
+              <CheckCheck className="size-4" />
+              {"모두 읽음"}
+            </Button>
+          )}
+        </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertCircle className="size-4" />
+            <AlertTitle>{"오류"}</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {isLoading ? (
+          <div className="flex justify-center py-20">
+            <Spinner className="size-8 text-primary" />
+          </div>
+        ) : notifications.length === 0 ? (
+          <Card className="border-dashed">
+            <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+              <Bell className="size-12 text-muted-foreground/50" />
+              <p className="text-sm text-muted-foreground">
+                {"알림이 없습니다."}
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {notifications.map((notification) => (
+              <Card
+                key={notification.notificationId}
+                className={`border-border/40 transition-colors ${
+                  !notification.read
+                    ? "border-primary/20 bg-primary/5"
+                    : ""
+                }`}
+              >
+                <CardContent className="flex items-start justify-between p-4">
+                  <div className="flex items-start gap-3">
+                    <div
+                      className={`flex size-10 shrink-0 items-center justify-center rounded-xl ${
+                        !notification.read ? "bg-primary/20" : "bg-muted"
+                      }`}
+                    >
+                      <Bell
+                        className={`size-5 ${
+                          !notification.read
+                            ? "text-primary"
+                            : "text-muted-foreground"
+                        }`}
+                      />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="text-sm font-medium text-foreground">
+                          {notification.title}
+                        </p>
+                        {!notification.read && (
+                          <Badge className="h-4 px-1.5 text-[10px]">
+                            {"NEW"}
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {notification.message}
+                      </p>
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        {new Date(notification.createdAt).toLocaleString(
+                          "ko-KR",
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                  {!notification.read && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="shrink-0 text-xs"
+                      disabled={markingId === notification.notificationId}
+                      onClick={() =>
+                        handleMarkAsRead(notification.notificationId)
+                      }
+                    >
+                      {markingId === notification.notificationId ? (
+                        <Spinner className="size-3" />
+                      ) : (
+                        "읽음"
+                      )}
+                    </Button>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/app/settings/reminders/page.tsx
+++ b/frontend/app/settings/reminders/page.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { AppShell } from "@/components/layout/app-shell";
+import { useAuth } from "@/contexts/auth-context";
+import {
+  getNotificationPreferences,
+  updateNotificationPreferences,
+  type NotificationPreferences,
+} from "@/lib/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { Spinner } from "@/components/ui/spinner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertCircle, Bell, Mail, Smartphone, MessageSquare, Check } from "lucide-react";
+
+const CHANNELS = [
+  { id: "EMAIL", label: "이메일", icon: Mail },
+  { id: "PUSH", label: "푸시 알림", icon: Smartphone },
+  { id: "IN_APP", label: "인앱 알림", icon: Bell },
+  { id: "KAKAO", label: "카카오톡", icon: MessageSquare },
+] as const;
+
+export default function ReminderSettingsPage() {
+  const { user, isLoading: isAuthLoading, isHydrated } = useAuth();
+  const router = useRouter();
+  const [prefs, setPrefs] = useState<NotificationPreferences | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (isHydrated && !isAuthLoading && !user) {
+      router.push("/login");
+    }
+  }, [user, isAuthLoading, isHydrated, router]);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await getNotificationPreferences(user.id);
+        setPrefs(res);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "설정을 불러오지 못했습니다.",
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    void load();
+  }, [user?.id]);
+
+  const toggleChannel = (channelId: string) => {
+    if (!prefs) return;
+    const channels = prefs.channels.includes(channelId)
+      ? prefs.channels.filter((c) => c !== channelId)
+      : [...prefs.channels, channelId];
+    setPrefs({ ...prefs, channels });
+  };
+
+  const handleSave = async () => {
+    if (!prefs || !user?.id) return;
+    setIsSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      const updated = await updateNotificationPreferences(user.id, prefs);
+      setPrefs(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "저장에 실패했습니다.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!isHydrated || isAuthLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <Spinner className="size-8 text-primary" />
+      </div>
+    );
+  }
+
+  if (!user) return null;
+
+  return (
+    <AppShell>
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-5 p-4 pb-24">
+        <div>
+          <h1 className="text-xl font-bold text-foreground">{"알림 설정"}</h1>
+          <p className="text-sm text-muted-foreground">
+            {"알림 채널과 마감 알림 시간을 설정합니다."}
+          </p>
+        </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertCircle className="size-4" />
+            <AlertTitle>{"오류"}</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {isLoading || !prefs ? (
+          <div className="flex justify-center py-20">
+            <Spinner className="size-8 text-primary" />
+          </div>
+        ) : (
+          <>
+            {/* 알림 채널 */}
+            <Card className="border-border/40">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-sm font-semibold">
+                  {"알림 채널"}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-4 pt-0">
+                {CHANNELS.map(({ id, label, icon: Icon }) => (
+                  <div key={id} className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="flex size-9 items-center justify-center rounded-lg bg-muted">
+                        <Icon className="size-4 text-muted-foreground" />
+                      </div>
+                      <Label
+                        htmlFor={`channel-${id}`}
+                        className="cursor-pointer text-sm font-medium"
+                      >
+                        {label}
+                      </Label>
+                    </div>
+                    <Switch
+                      id={`channel-${id}`}
+                      checked={prefs.channels.includes(id)}
+                      onCheckedChange={() => toggleChannel(id)}
+                    />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            {/* 알림 종류 */}
+            <Card className="border-border/40">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-sm font-semibold">
+                  {"알림 종류"}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-4 pt-0">
+                <div className="flex items-center justify-between">
+                  <Label
+                    htmlFor="quiz-notif"
+                    className="cursor-pointer text-sm font-medium"
+                  >
+                    {"퀴즈 알림"}
+                  </Label>
+                  <Switch
+                    id="quiz-notif"
+                    checked={prefs.quizNotifications}
+                    onCheckedChange={(v) =>
+                      setPrefs({ ...prefs, quizNotifications: v })
+                    }
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <Label
+                    htmlFor="material-notif"
+                    className="cursor-pointer text-sm font-medium"
+                  >
+                    {"학습 자료 알림"}
+                  </Label>
+                  <Switch
+                    id="material-notif"
+                    checked={prefs.materialNotifications}
+                    onCheckedChange={(v) =>
+                      setPrefs({ ...prefs, materialNotifications: v })
+                    }
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <Label
+                    htmlFor="deadline-notif"
+                    className="cursor-pointer text-sm font-medium"
+                  >
+                    {"마감일 알림"}
+                  </Label>
+                  <Switch
+                    id="deadline-notif"
+                    checked={prefs.deadlineNotifications}
+                    onCheckedChange={(v) =>
+                      setPrefs({ ...prefs, deadlineNotifications: v })
+                    }
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* 마감 알림 시간 (deadlineNotifications 켜져 있을 때만) */}
+            {prefs.deadlineNotifications && (
+              <Card className="border-border/40">
+                <CardHeader className="pb-1">
+                  <CardTitle className="text-sm font-semibold">
+                    {"마감 알림 시간"}
+                  </CardTitle>
+                  <p className="text-xs text-muted-foreground">
+                    {"마감 몇 시간 전에 알림을 받을지 설정합니다."}
+                  </p>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4 pt-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">
+                      {"알림 시간"}
+                    </span>
+                    <span className="text-sm font-semibold text-primary">
+                      {prefs.deadlineHoursBefore}
+                      {"시간 전"}
+                    </span>
+                  </div>
+                  <Slider
+                    min={1}
+                    max={72}
+                    step={1}
+                    value={[prefs.deadlineHoursBefore]}
+                    onValueChange={([v]) =>
+                      setPrefs({ ...prefs, deadlineHoursBefore: v })
+                    }
+                  />
+                  <div className="flex justify-between text-xs text-muted-foreground">
+                    <span>{"1시간"}</span>
+                    <span>{"72시간"}</span>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            <Button className="w-full gap-2" onClick={handleSave} disabled={isSaving}>
+              {isSaving ? (
+                <>
+                  <Spinner className="size-4" />
+                  {"저장 중..."}
+                </>
+              ) : saved ? (
+                <>
+                  <Check className="size-4" />
+                  {"저장 완료!"}
+                </>
+              ) : (
+                "설정 저장"
+              )}
+            </Button>
+          </>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/components/announcements/teacher-announcements.tsx
+++ b/frontend/components/announcements/teacher-announcements.tsx
@@ -16,6 +16,8 @@ import {
   Send,
   FileText,
   Users,
+  Share2,
+  Loader2,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -27,6 +29,7 @@ import {
   getNotices,
   getNoticeSettings,
   updateNoticeSettings,
+  publishAnnouncement,
   type Announcement,
   type NoticeSettings,
 } from "@/lib/api";
@@ -80,6 +83,8 @@ export function TeacherAnnouncements() {
   const [notices, setNotices] = useState<Announcement[]>([]);
   const [settings, setSettings] = useState<NoticeSettings | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [publishingId, setPublishingId] = useState<string | null>(null);
+  const [publishedIds, setPublishedIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (!user?.id) return;
@@ -100,6 +105,21 @@ export function TeacherAnnouncements() {
     };
     void load();
   }, [user?.id]);
+
+  const handlePublishToLms = async (courseId: string, announcementId: string) => {
+    setPublishingId(announcementId);
+    setError(null);
+    try {
+      await publishAnnouncement(courseId, announcementId);
+      setPublishedIds((prev) => new Set(prev).add(announcementId));
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "LMS 배포에 실패했습니다.",
+      );
+    } finally {
+      setPublishingId(null);
+    }
+  };
 
   const handleSaveSettings = async () => {
     if (!settings || !user?.id) return;
@@ -266,6 +286,34 @@ export function TeacherAnnouncements() {
                           <Users className="mr-2 size-4" />
                           {"읽은 학생 확인"}
                         </DropdownMenuItem>
+                        {typeof announcement.id === "string" && (
+                          <DropdownMenuItem
+                            disabled={
+                              publishingId === announcement.id ||
+                              publishedIds.has(announcement.id)
+                            }
+                            onClick={() => {
+                              const notice = notices.find(
+                                (n) => n.announcementId === announcement.id,
+                              );
+                              if (notice) {
+                                void handlePublishToLms(
+                                  notice.courseId,
+                                  notice.announcementId,
+                                );
+                              }
+                            }}
+                          >
+                            {publishingId === announcement.id ? (
+                              <Loader2 className="mr-2 size-4 animate-spin" />
+                            ) : (
+                              <Share2 className="mr-2 size-4" />
+                            )}
+                            {publishedIds.has(announcement.id)
+                              ? "LMS 배포 완료"
+                              : "LMS 배포"}
+                          </DropdownMenuItem>
+                        )}
                       </DropdownMenuContent>
                     </DropdownMenu>
                   </div>

--- a/frontend/components/dashboard/student-dashboard.tsx
+++ b/frontend/components/dashboard/student-dashboard.tsx
@@ -19,6 +19,9 @@ import {
   Loader2,
   AlertCircle,
   ArrowRight,
+  XCircle,
+  ChevronDown,
+  ChevronUp,
 } from "lucide-react";
 import {
   getStudentQuizHistory,
@@ -31,6 +34,17 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useCourse } from "@/contexts/course-context";
 import { CourseInfoBanner } from "@/components/layout/course-info-banner";
 
+// 날짜를 "N일 전", "오늘" 등으로 변환
+function relativeDate(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  if (days === 0) return "오늘";
+  if (days === 1) return "어제";
+  if (days < 7) return `${days}일 전`;
+  if (days < 30) return `${Math.floor(days / 7)}주 전`;
+  return new Date(dateStr).toLocaleDateString("ko-KR");
+}
+
 export function StudentDashboard() {
   const router = useRouter();
   const { user, isLoading: isAuthLoading } = useAuth();
@@ -39,6 +53,7 @@ export function StudentDashboard() {
   const [materials, setMaterials] = useState<StudentMaterialItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showAllWrongAnswers, setShowAllWrongAnswers] = useState(false);
 
   useEffect(() => {
     if (isAuthLoading) return;
@@ -148,8 +163,35 @@ export function StudentDashboard() {
     }));
   }, [quizHistory]);
 
-  const studyMaterials = useMemo(() => {
-    return materials.slice(0, 3);
+  // 오답 복습 — 최근 퀴즈에서 틀린 문제 수집
+  const wrongAnswers = useMemo(() => {
+    return quizHistory
+      .slice(0, 5)
+      .flatMap((sub) =>
+        (sub.wrongAnswers || []).map((wa) => ({
+          ...wa,
+          submittedAt: sub.submittedAt,
+          quizScore: sub.score,
+        })),
+      )
+      .slice(0, 10);
+  }, [quizHistory]);
+
+  // 자료 타임라인 — 날짜 기준 그룹화
+  const materialsTimeline = useMemo(() => {
+    const sorted = [...materials].sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
+    const groups = new Map<string, StudentMaterialItem[]>();
+    sorted.forEach((m) => {
+      const label = relativeDate(m.createdAt);
+      if (!groups.has(label)) groups.set(label, []);
+      groups.get(label)!.push(m);
+    });
+
+    return Array.from(groups.entries()).slice(0, 4); // 최대 4개 그룹
   }, [materials]);
 
   const courseProgress = useMemo(() => {
@@ -337,6 +379,11 @@ export function StudentDashboard() {
                       </p>
                       <p className="text-xs text-muted-foreground">
                         {`${quiz.correctCount}/${quiz.totalCount} 정답`}
+                        {quiz.wrongAnswerCount > 0 && (
+                          <span className="ml-2 text-red-500">
+                            {`오답 ${quiz.wrongAnswerCount}개`}
+                          </span>
+                        )}
                       </p>
                     </div>
                   </div>
@@ -369,59 +416,163 @@ export function StudentDashboard() {
         </div>
       </section>
 
-      {/* 최근 학습 자료 */}
+      {/* 오답 복습 */}
+      {wrongAnswers.length > 0 && (
+        <section>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-foreground">
+              {"오답 복습"}
+            </h2>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 text-xs text-primary"
+              onClick={() => setShowAllWrongAnswers((v) => !v)}
+            >
+              {showAllWrongAnswers ? (
+                <>
+                  {"접기"}
+                  <ChevronUp className="size-3" />
+                </>
+              ) : (
+                <>
+                  {`전체 ${wrongAnswers.length}개`}
+                  <ChevronDown className="size-3" />
+                </>
+              )}
+            </Button>
+          </div>
+          <div className="flex flex-col gap-2">
+            {(showAllWrongAnswers ? wrongAnswers : wrongAnswers.slice(0, 3)).map(
+              (wa, idx) => (
+                <Card
+                  key={`${wa.questionId}-${idx}`}
+                  className="border-red-200/40 bg-red-50/30 dark:border-red-900/30 dark:bg-red-950/10"
+                >
+                  <CardContent className="p-4">
+                    <div className="flex items-start gap-3">
+                      <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-red-500/10">
+                        <XCircle className="size-4 text-red-500" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        {wa.content && (
+                          <p className="text-sm font-medium text-foreground line-clamp-2">
+                            {wa.content}
+                          </p>
+                        )}
+                        <div className="mt-2 flex flex-col gap-1">
+                          {wa.selectedOption && (
+                            <p className="text-xs text-red-500">
+                              {"내 답: "}
+                              <span className="font-medium">
+                                {wa.selectedOption}
+                              </span>
+                            </p>
+                          )}
+                          {wa.correctAnswer && (
+                            <p className="text-xs text-emerald-600">
+                              {"정답: "}
+                              <span className="font-medium">
+                                {wa.correctAnswer}
+                              </span>
+                            </p>
+                          )}
+                        </div>
+                        <p className="mt-2 text-xs text-muted-foreground">
+                          {relativeDate(wa.submittedAt)}
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ),
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* 예습/복습 자료 타임라인 */}
       <section>
         <div className="mb-3 flex items-center justify-between">
           <h2 className="text-sm font-semibold text-foreground">
-            {"새로운 학습 자료"}
+            {"학습 자료 타임라인"}
           </h2>
           <Button
             variant="ghost"
             size="sm"
             className="h-7 text-xs text-primary"
+            onClick={() => router.push("/materials")}
           >
             {"모두 보기"}
           </Button>
         </div>
-        <ScrollArea className="w-full">
-          <div className="flex gap-3 pb-2">
-            {studyMaterials.length > 0 ? (
-              studyMaterials.map((material) => (
-                <Card
-                  key={material.id}
-                  className="min-w-[200px] shrink-0 border-border/40"
-                >
-                  <CardContent className="p-4">
-                    <div className="flex items-start justify-between">
-                      <Badge
-                        variant={
-                          material.type === "PREVIEW" ? "default" : "secondary"
-                        }
-                        className="text-xs"
-                      >
-                        {material.type === "PREVIEW" ? "예습" : "복습"}
-                      </Badge>
-                      <span className="flex size-2 rounded-full bg-primary" />
-                    </div>
-                    <p className="mt-3 text-sm font-medium text-foreground">
-                      {material.title}
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {new Date(material.createdAt).toLocaleDateString("ko-KR")}
-                    </p>
-                  </CardContent>
-                </Card>
-              ))
-            ) : (
-              <Card className="min-w-[200px] shrink-0 border-border/40">
-                <CardContent className="p-4 text-center text-xs text-muted-foreground">
-                  {"새로운 자료가 없습니다."}
-                </CardContent>
-              </Card>
-            )}
+
+        {materialsTimeline.length > 0 ? (
+          <div className="relative flex flex-col gap-0 pl-4">
+            {/* 세로 타임라인 선 */}
+            <div className="absolute left-[7px] top-2 bottom-2 w-px bg-border/60" />
+            {materialsTimeline.map(([dateLabel, items], groupIdx) => (
+              <div key={dateLabel} className="relative mb-4 last:mb-0">
+                {/* 타임라인 점 */}
+                <div className="absolute -left-4 top-1 flex size-4 items-center justify-center">
+                  <div
+                    className={`size-2 rounded-full ${groupIdx === 0 ? "bg-primary" : "bg-border"}`}
+                  />
+                </div>
+                <p className="mb-2 text-xs font-semibold text-muted-foreground">
+                  {dateLabel}
+                </p>
+                <div className="flex flex-col gap-2">
+                  {items.map((material) => (
+                    <Card
+                      key={material.id}
+                      className="border-border/40"
+                    >
+                      <CardContent className="flex items-center gap-3 p-3">
+                        <div
+                          className={`flex size-8 shrink-0 items-center justify-center rounded-lg ${
+                            material.type === "PREVIEW"
+                              ? "bg-blue-500/10"
+                              : "bg-violet-500/10"
+                          }`}
+                        >
+                          {material.type === "PREVIEW" ? (
+                            <Star
+                              className="size-4 text-blue-500"
+                            />
+                          ) : (
+                            <CheckCircle className="size-4 text-violet-500" />
+                          )}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="truncate text-sm font-medium text-foreground">
+                            {material.title}
+                          </p>
+                        </div>
+                        <Badge
+                          variant={
+                            material.type === "PREVIEW"
+                              ? "default"
+                              : "secondary"
+                          }
+                          className="shrink-0 text-xs"
+                        >
+                          {material.type === "PREVIEW" ? "예습" : "복습"}
+                        </Badge>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </div>
+            ))}
           </div>
-          <ScrollBar orientation="horizontal" />
-        </ScrollArea>
+        ) : (
+          <Card className="border-border/40">
+            <CardContent className="p-4 text-center text-sm text-muted-foreground">
+              {"학습 자료가 없습니다."}
+            </CardContent>
+          </Card>
+        )}
       </section>
 
       {/* 과목별 진도 */}

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -12,6 +12,7 @@ import {
   BookOpen,
   Plus,
   Loader2,
+  Calendar,
 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -263,7 +264,14 @@ export function Header() {
           </div>
         </div>
 
-        {/* 우측: 프로필 */}
+        {/* 우측: 알림 + 프로필 */}
+        <div className="flex items-center gap-1">
+        <Button variant="ghost" size="icon" className="shrink-0 hover:bg-primary/10" asChild>
+          <Link href="/notifications">
+            <Bell className="size-5 text-foreground" />
+            <span className="sr-only">{"알림"}</span>
+          </Link>
+        </Button>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -310,6 +318,24 @@ export function Header() {
               <User className="mr-3 size-4 text-muted-foreground" />
               {"프로필 설정"}
             </DropdownMenuItem>
+            <DropdownMenuItem className="cursor-pointer rounded-lg p-3" asChild>
+              <Link href="/notifications">
+                <Bell className="mr-3 size-4 text-muted-foreground" />
+                {"알림"}
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem className="cursor-pointer rounded-lg p-3" asChild>
+              <Link href="/deadlines">
+                <Calendar className="mr-3 size-4 text-muted-foreground" />
+                {"마감일"}
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem className="cursor-pointer rounded-lg p-3" asChild>
+              <Link href="/settings/reminders">
+                <Settings className="mr-3 size-4 text-muted-foreground" />
+                {"알림 설정"}
+              </Link>
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               className="cursor-pointer rounded-lg p-3"
@@ -327,6 +353,7 @@ export function Header() {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        </div>
       </div>
 
       <EditProfileModal

--- a/frontend/components/materials/teacher-materials.tsx
+++ b/frontend/components/materials/teacher-materials.tsx
@@ -50,6 +50,7 @@ import {
 import { Loader2 } from "lucide-react";
 import { useCourse } from "@/contexts/course-context";
 import { CourseInfoBanner } from "@/components/layout/course-info-banner";
+import { useRealtimeSubscription } from "@/lib/hooks/use-realtime-subscription";
 
 type SchedulePreview = {
   scheduleId: string;
@@ -141,56 +142,49 @@ export function TeacherMaterials() {
     void loadData();
   }, [courseId]);
 
-  // Poll audio transcription status
-  useEffect(() => {
-    if (!courseId || !audioTask || audioTask.status === "COMPLETED" || audioTask.status === "FAILED") {
-      return;
-    }
+  // ── 오디오 변환 상태: Supabase Realtime 구독 ──
+  // audios 테이블의 해당 레코드가 UPDATE되면 즉시 상태 반영
+  useRealtimeSubscription({
+    table: "audios",
+    filter: audioTask?.audioId ? `id=eq.${audioTask.audioId}` : undefined,
+    event: "UPDATE",
+    enabled: !!courseId && !!audioTask?.audioId &&
+      audioTask.status !== "COMPLETED" && audioTask.status !== "FAILED",
+    onUpdate: (payload) => {
+      const row = payload.new;
+      setAudioTask((prev: typeof audioTask) => prev
+        ? {
+            ...prev,
+            status: (row.status as string) ?? prev.status,
+            transcriptText: (row.transcript_text as string | undefined) ?? prev.transcriptText,
+          }
+        : prev,
+      );
+    },
+  });
 
-    const intervalId = window.setInterval(async () => {
-      try {
-        const task = await getAudioConvertTask(
-          courseId,
-          audioTask.audioId
-        );
-        setAudioTask(task);
-      } catch {
-        window.clearInterval(intervalId);
-      }
-    }, 2000);
-
-    return () => window.clearInterval(intervalId);
-  }, [audioTask, courseId]);
-
-  // ── 스크립트 상태 폴링 ──
-  useEffect(() => {
-    const hasAnalyzing = scripts.some((s) => s.status === "analyzing");
-    if (!hasAnalyzing || !courseId) return;
-
-    const interval = setInterval(async () => {
-      try {
-        const scriptData = await getCourseScripts(courseId);
-        const list = scriptData.scripts;
-        if (Array.isArray(list)) {
-          setScripts(
-            list.map((s: CourseScriptListItem) => ({
-              id: s.scriptId,
-              scheduleId: s.scheduleId,
-              title: s.title || s.fileName || "업로드된 자료",
-              format: (s.fileName.split(".").pop() || "문서").toUpperCase(),
-              uploadDate: new Date(s.uploadedAt).toLocaleDateString(),
-              status: s.status === "completed" ? "completed" : "analyzing",
-              progress: 0,
-              issues: 0,
-            })),
-          );
-        }
-      } catch (e) {
-        console.error("스크립트 폴링 실패:", e);
-      }
-    }, 5000);
-    return () => clearInterval(interval);
-  }, [scripts, courseId]);
+  // ── 스크립트 분석 상태: Supabase Realtime 구독 ──
+  // scripts 테이블에서 해당 강의 스크립트가 UPDATE되면 상태 갱신
+  useRealtimeSubscription({
+    table: "scripts",
+    filter: courseId ? `course_id=eq.${courseId}` : undefined,
+    event: "UPDATE",
+    enabled: !!courseId && scripts.some((s) => s.status === "analyzing"),
+    onUpdate: (payload) => {
+      const row = payload.new;
+      if (!row.id) return;
+      setScripts((prev) =>
+        prev.map((s) =>
+          s.id === row.id
+            ? {
+                ...s,
+                status: (row.status as string) === "completed" ? "completed" : "analyzing",
+              }
+            : s,
+        ),
+      );
+    },
+  });
 
   // ── 남은 시간 시뮬레이션 ──
   useEffect(() => {

--- a/frontend/lib/hooks/use-realtime-subscription.ts
+++ b/frontend/lib/hooks/use-realtime-subscription.ts
@@ -1,0 +1,74 @@
+"use client";
+
+/**
+ * Supabase Realtime 채널 구독 훅.
+ *
+ * 사용 예:
+ *   useRealtimeSubscription({
+ *     table: "scripts",
+ *     filter: `course_id=eq.${courseId}`,
+ *     event: "UPDATE",
+ *     onUpdate: (payload) => { ... },
+ *     enabled: !!courseId,
+ *   });
+ */
+
+import { useEffect, useRef } from "react";
+import type { RealtimeChannel } from "@supabase/supabase-js";
+import { supabase } from "@/lib/supabase/client";
+
+export interface RealtimeSubscriptionOptions {
+  /** Supabase public 테이블명 */
+  table: string;
+  /** PostgREST 필터 문자열 (e.g. "course_id=eq.abc") — 없으면 전체 테이블 구독 */
+  filter?: string;
+  /** 구독할 이벤트 종류 (기본: UPDATE) */
+  event?: "INSERT" | "UPDATE" | "DELETE" | "*";
+  /** 변경 감지 시 호출될 콜백 */
+  onUpdate: (payload: { new: Record<string, unknown>; old: Record<string, unknown> }) => void;
+  /** false이면 구독하지 않음 (조건부 구독에 사용) */
+  enabled?: boolean;
+}
+
+export function useRealtimeSubscription({
+  table,
+  filter,
+  event = "UPDATE",
+  onUpdate,
+  enabled = true,
+}: RealtimeSubscriptionOptions) {
+  // onUpdate가 매 렌더에 새 참조를 만들어도 재구독이 일어나지 않도록 ref로 래핑
+  const onUpdateRef = useRef(onUpdate);
+  onUpdateRef.current = onUpdate;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const channelName = filter
+      ? `rt:${table}:${filter}`
+      : `rt:${table}`;
+
+    const channel: RealtimeChannel = supabase
+      .channel(channelName)
+      .on(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        "postgres_changes" as any,
+        {
+          event,
+          schema: "public",
+          table,
+          ...(filter ? { filter } : {}),
+        },
+        (payload: { new: Record<string, unknown>; old: Record<string, unknown> }) => {
+          onUpdateRef.current(payload);
+        },
+      )
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  // filter와 table이 바뀌면 재구독, onUpdate 변경에는 재구독하지 않음
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [table, filter, event, enabled]);
+}


### PR DESCRIPTION
## Phase 2 — 사용자 경험 완성

### 2-A. 알림 페이지 신규 구현
- app/notifications/page.tsx: 인앱 알림 목록 + 개별/전체 읽음 처리
- header에 Bell 아이콘 버튼 및 프로필 드롭다운 메뉴 항목 추가

### 2-B. 마감일/리마인더 설정 페이지 신규 구현
- app/deadlines/page.tsx: 강의별 마감일 리스트 + 개별 dismiss
- app/settings/reminders/page.tsx: 알림 채널(EMAIL/PUSH/IN_APP/KAKAO) + 알림 종류 토글 + 마감 N시간 전 슬라이더

### 2-C. 학생 대시보드 보강
- 오답 복습 섹션: 최근 퀴즈 틀린 문제 목록 (내 답 vs 정답), 펼치기/접기
- 학습 자료 타임라인: 날짜 기준 그룹화 + 좌측 세로선 UI

### 2-D. 공지사항 LMS 배포 플로우
- teacher-announcements.tsx 드롭다운에 "LMS 배포" 항목 추가
- publishAnnouncement(courseId, announcementId) 연동 + 배포 완료 상태 표시

## Phase 3 — 안정화

### 3-A. SMTP 이메일 연동 완성
- config.py: SUPABASE_JWKS_URL/ISSUER 미정의 필드 추가 (AttributeError 수정)
- scheduler.py: _build_email_html() HTML 템플릿 추가, _send_email을 MIMEMultipart("alternative") + HTML 파트로 업그레이드

### 3-B. Supabase Realtime 구독 표준화
- lib/hooks/use-realtime-subscription.ts 신규 훅 생성
- teacher-materials.tsx의 오디오(2s)/스크립트(5s) setInterval 폴링을 Supabase Realtime postgres_changes 구독으로 전환

### 3-C. 백엔드 통합 테스트 (36개 → 53개)
- test_ai_simulation.py: assessment/answer/grade _run_* 상태 전이 7개
- test_scheduler_smtp.py: HTML 템플릿, SMTP 발송/스킵, IN_APP INSERT, send_pending_reminders SENT/FAILED 흐름 8개

<!--
[Pull Request Template]

- PR에는 반드시 스크린샷(또는 GIF)을 첨부합니다.
- 리뷰어는 스크린샷을 기준으로 변경 사항을 1차 확인합니다.
- 이슈 설명을 반복하지 말고, 변경된 결과 중심으로 작성합니다.
-->
## 🚀 변경 사항
> 이번 작업으로 무엇이 바뀌었나요?

- 
- 

---


## 이슈 연결
<!--
PR merge 시 이슈가 자동으로 닫히도록 설정합니다.
-->
Closes #85

---

## 📸 스크린샷
<!--
필수 항목입니다.
변경 전 / 변경 후 또는 데스크탑 / 모바일 스크린샷을 첨부합니다.
GIF도 가능하며, 인터랙션이 있는 경우 우선 첨부합니다.
-->

---

## 🧪 체크리스트
<!--
PR 생성 전 반드시 확인합니다.
-->
- [ ] 스크린샷 또는 GIF 첨부
- [ ] 로컬 환경에서 정상 작동 확인
- [ ] 주요 기능 테스트 완료
- [ ] 관련 없는 파일 변경 없음

---

## 참고 사항
<!--
리뷰 시 참고할 맥락이나 추후 개선 포인트를 작성합니다.
-->
