### PR TITLE
fix: 예습, 복습 생성 오류 및 주차 지정

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,8 +71,14 @@ app.include_router(notices.router)
 app.include_router(dashboard.router)
 app.include_router(analysis.router)
 app.include_router(content.materials_router)
-app.include_router(content.preview_router)
-app.include_router(content.review_router)
+app.include_router(
+    content.preview_router,
+    prefix="/api/courses/{course_id}/schedules/{schedule_id}",
+)
+app.include_router(
+    content.review_router,
+    prefix="/api/courses/{course_id}/schedules/{schedule_id}",
+)
 app.include_router(ai_simulation.router)
 app.include_router(notifications.router)
 app.include_router(reminders.deadlines_router)

--- a/backend/app/routers/content.py
+++ b/backend/app/routers/content.py
@@ -15,17 +15,14 @@ from ..database import supabase
 from ..dependencies import require_instructor_of
 
 materials_router = APIRouter(
-    prefix="/api/courses/{course_id}/materials",
     tags=["content"],
 )
 
 # 두 리소스의 URL 계층이 다르므로 별도 router 객체 사용
 preview_router = APIRouter(
-    prefix="/api/courses/{course_id}/schedules/{schedule_id}/preview-guides",
     tags=["content"],
 )
 review_router = APIRouter(
-    prefix="/api/courses/{course_id}/schedules/{schedule_id}/review-summaries",
     tags=["content"],
 )
 

--- a/backend/app/routers/scripts.py
+++ b/backend/app/routers/scripts.py
@@ -281,6 +281,41 @@ def get_script(course_id: str, script_id: str, current_user: dict = Depends(get_
     return script
 
 
+# ── 스크립트 수정 (제목/주차) ───────────────────────────────────────────────────
+@router.put("/{script_id}")
+def update_script(
+    course_id: str,
+    script_id: str,
+    payload: dict,
+    current_user: dict = Depends(require_instructor),
+):
+    require_instructor_of(course_id, current_user["id"])
+
+    update_data = {}
+    if "title" in payload:
+        update_data["title"] = payload["title"]
+    if "weekNumber" in payload:
+        update_data["week_number"] = payload["weekNumber"]
+    if "scheduleId" in payload:
+        update_data["schedule_id"] = payload["scheduleId"]
+
+    if not update_data:
+        raise HTTPException(status_code=400, detail="수정할 데이터가 없습니다.")
+
+    result = (
+        supabase.table("scripts")
+        .update(update_data)
+        .eq("id", script_id)
+        .eq("course_id", course_id)
+        .maybe_single()
+        .execute()
+    )
+    if not result.data:
+        raise HTTPException(status_code=404, detail="스크립트를 찾을 수 없습니다.")
+
+    return _format_script(result.data)
+
+
 # ── 스크립트 삭제 ─────────────────────────────────────────────────────────────
 @router.delete("/{script_id}", status_code=204)
 def delete_script(

--- a/frontend/components/materials/teacher-materials.tsx
+++ b/frontend/components/materials/teacher-materials.tsx
@@ -16,19 +16,40 @@ import {
   FileUp,
   Mic,
   AlertTriangle,
+  Settings2,
 } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   getCourseSchedules,
   getPreviewGuide,
   getReviewSummary,
   getCourseScripts,
   uploadScript,
+  updateScript,
   uploadAudio,
   getAudioConvertTask,
   listAudios,
@@ -68,6 +89,21 @@ export function TeacherMaterials() {
 
   const [schedules, setSchedules] = useState<SchedulePreview[]>([]);
   const [scripts, setScripts] = useState<any[]>([]);
+  
+  // 모달 상태
+  const [uploadModal, setUploadModal] = useState({
+    open: false,
+    file: null as File | null,
+    title: "",
+    scheduleId: "none",
+  });
+  const [editModal, setEditModal] = useState({
+    open: false,
+    scriptId: "",
+    title: "",
+    scheduleId: "none",
+  });
+
   const [simulatedProgress, setSimulatedProgress] = useState<
     Record<string, { progress: number; remaining: number }>
   >({});
@@ -614,84 +650,31 @@ export function TeacherMaterials() {
                         </p>
                       </div>
                     </div>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon" className="size-8">
-                          <MoreVertical className="size-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem>
-                          <Eye className="mr-2 size-4" />
-                          {"미리보기"}
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </TabsContent>
-
-        <TabsContent value="scripts" className="mt-4">
-          <div className="flex flex-col gap-3">
-            {scripts.length === 0 && (
-              <p className="py-8 text-center text-sm text-muted-foreground">
-                {"업로드된 스크립트가 없습니다."}
-              </p>
-            )}
-            {scripts.map((script) => (
-              <Card key={script.id} className="border-border/40">
-                <CardContent className="p-4">
-                  <div className="flex flex-col gap-3">
-                    <div className="flex items-start gap-3">
-                      <div className="flex size-10 items-center justify-center rounded-xl bg-primary/10">
-                        <FileText className="size-5 text-primary" />
-                      </div>
-                      <div className="flex-1">
-                        <div className="flex items-center gap-2">
-                          <Badge variant="outline" className="text-xs">
-                            {script.format}
-                          </Badge>
-                          <Badge variant="secondary" className="text-xs">
-                            {script.weekNumber ? `${script.weekNumber}주차` : "주차 미지정"}
-                          </Badge>
-                        </div>
-                        <p className="mt-1 font-medium text-foreground">
-                          {script.title}
-                        </p>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {script.uploadDate}
-                        </p>
-                        {script.status === "analyzing" && (
-                          <div className="mt-2 flex items-center gap-2">
-                            <Progress
-                              value={
-                                simulatedProgress[script.id]?.progress || 0
-                              }
-                              className="h-1.5 flex-1"
-                            />
-                            <span className="w-10 text-right text-xs font-medium text-primary">
-                              {simulatedProgress[script.id]?.progress || 0}%
-                            </span>
-                            <span className="w-14 text-right text-xs text-muted-foreground tabular-nums">
-                              {simulatedProgress[script.id]?.remaining || 45}초
-                              남음
-                            </span>
-                          </div>
-                        )}
-                        {script.status === "completed" &&
-                          script.issues &&
-                          script.issues > 0 && (
-                            <div className="mt-2 flex items-center gap-2 text-xs">
-                              <AlertTriangle className="size-3 text-amber-500" />
-                              <span className="text-amber-500">
-                                {script.issues}
-                                {"개의 보완점 발견"}
-                              </span>
-                            </div>
-                          )}
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="icon" className="size-8">
+                              <MoreVertical className="size-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuLabel>{"자료 관리"}</DropdownMenuLabel>
+                            <DropdownMenuItem
+                              onClick={() => setEditModal({
+                                open: true,
+                                scriptId: script.id,
+                                title: script.title,
+                                scheduleId: script.scheduleId || "none"
+                              })}
+                            >
+                              <Settings2 className="mr-2 size-4" />
+                              {"정보 수정 (주차 변경)"}
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem className="text-destructive">
+                              {"삭제"}
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                       </div>
                     </div>
                     {script.status === "completed" && (
@@ -737,6 +720,92 @@ export function TeacherMaterials() {
           </div>
         </TabsContent>
       </Tabs>
+
+      {/* 업로드 확인 모달 */}
+      <Dialog open={uploadModal.open} onOpenChange={(open) => setUploadModal(prev => ({ ...prev, open }))}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>{"강의 자료 업로드"}</DialogTitle>
+            <DialogDescription>{"업로드할 자료의 제목과 주차를 확인해주세요."}</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="title">{"자료 제목"}</Label>
+              <Input
+                id="title"
+                value={uploadModal.title}
+                onChange={(e) => setUploadModal(prev => ({ ...prev, title: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>{"대상 주차"}</Label>
+              <Select
+                value={uploadModal.scheduleId}
+                onValueChange={(val) => setUploadModal(prev => ({ ...prev, scheduleId: val }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="주차 선택" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">{"주차 미지정"}</SelectItem>
+                  {schedules.map(s => (
+                    <SelectItem key={s.scheduleId} value={s.scheduleId}>
+                      {s.weekNumber}{"주차: "}{s.topic}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setUploadModal(prev => ({ ...prev, open: false }))}>{"취소"}</Button>
+            <Button onClick={handleScriptUploadConfirm} disabled={isUploadingScript}>{"업로드 시작"}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 정보 수정 모달 */}
+      <Dialog open={editModal.open} onOpenChange={(open) => setEditModal(prev => ({ ...prev, open }))}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>{"자료 정보 수정"}</DialogTitle>
+            <DialogDescription>{"자료의 제목이나 배정된 주차를 변경할 수 있습니다."}</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-title">{"자료 제목"}</Label>
+              <Input
+                id="edit-title"
+                value={editModal.title}
+                onChange={(e) => setEditModal(prev => ({ ...prev, title: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>{"주차 변경"}</Label>
+              <Select
+                value={editModal.scheduleId}
+                onValueChange={(val) => setEditModal(prev => ({ ...prev, scheduleId: val }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="주차 선택" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">{"주차 미지정"}</SelectItem>
+                  {schedules.map(s => (
+                    <SelectItem key={s.scheduleId} value={s.scheduleId}>
+                      {s.weekNumber}{"주차: "}{s.topic}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditModal(prev => ({ ...prev, open: false }))}>{"취소"}</Button>
+            <Button onClick={handleUpdateScriptConfirm}>{"수정 완료"}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* 트랜스크립트 보기 시트 */}
       <Sheet

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1085,6 +1085,17 @@ export async function uploadScript(
   };
 }
 
+export async function updateScript(
+  courseId: string,
+  scriptId: string,
+  payload: { title?: string; weekNumber?: number; scheduleId?: string | null },
+): Promise<CourseScriptListItem> {
+  return request(`/api/courses/${courseId}/scripts/${scriptId}`, {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  });
+}
+
 export async function getCourseScripts(
   courseId: string,
 ): Promise<{ scripts: CourseScriptListItem[] }> {


### PR DESCRIPTION
<!--
[Pull Request Template]

- PR에는 반드시 스크린샷(또는 GIF)을 첨부합니다.
- 리뷰어는 스크린샷을 기준으로 변경 사항을 1차 확인합니다.
- 이슈 설명을 반복하지 말고, 변경된 결과 중심으로 작성합니다.
-->
## 🚀 변경 사항
> 이번 작업으로 무엇이 바뀌었나요?
- 중복 경로 제거: content.py 내부에서 정의된 불필요한 prefix를
      삭제했습니다.
- 통합 경로 등록: main.py에서
      /api/courses/{course_id}/schedules/{schedule_id} 하위로 예습/복습
      라우터를 정확히 연결했습니다.
- 자료 업로드 시 주차 선택: 파일 업로드 버튼 옆에 현재 강의의
      주차(스케줄) 목록을 보여주는 선택창을 추가하여, 업로드와 동시에 주차를
      지정할 수 있게 합니다.
- 업로드 후 주차 수정: '주차 미지정'이거나 잘못 지정된 자료에 대해,
      목록에서 주차를 변경할 수 있는 기능을 추가합니다.
- 백엔드 지원: 스크립트의 주차 정보를 업데이트하는 API를 확인하고
      보강합니다.

---


## 이슈 연결
<!--
PR merge 시 이슈가 자동으로 닫히도록 설정합니다.
-->
Closes #이슈번호

---

## 📸 스크린샷
<!--
필수 항목입니다.
변경 전 / 변경 후 또는 데스크탑 / 모바일 스크린샷을 첨부합니다.
GIF도 가능하며, 인터랙션이 있는 경우 우선 첨부합니다.
-->

---

## 🧪 체크리스트
<!--
PR 생성 전 반드시 확인합니다.
-->
- [ ] 스크린샷 또는 GIF 첨부
- [ ] 로컬 환경에서 정상 작동 확인
- [ ] 주요 기능 테스트 완료
- [ ] 관련 없는 파일 변경 없음

---

## 참고 사항
<!--
리뷰 시 참고할 맥락이나 추후 개선 포인트를 작성합니다.
-->
