### PR TITLE
feat: UX 완성 (LMS 배포 UI, 퀴즈 상세 결과 뷰, 오디오 트랜스크립트 뷰어)

### DIFF
--- a/backend/app/routers/quiz.py
+++ b/backend/app/routers/quiz.py
@@ -398,6 +398,74 @@ class QuizSubmitRequest(BaseModel):
     answers: list[SubmitAnswer]
 
 
+# ── 5.3 퀴즈 응시 결과 상세 뷰 ───────────────────────────────────────────────────
+
+@router.get("/{quiz_id}/submissions/me")
+def get_my_submission(
+    course_id: str,
+    quiz_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    student_id = current_user["id"]
+
+    # 제출 내역 확인
+    sub = (
+        supabase.table("quiz_submissions")
+        .select("*")
+        .eq("quiz_id", quiz_id)
+        .eq("student_id", student_id)
+        .maybe_single()
+        .execute()
+    )
+    if not sub.data:
+        raise HTTPException(status_code=404, detail="제출 내역이 없습니다.")
+
+    submission_id = sub.data["id"]
+
+    # 퀴즈 및 문항 정보 조회 (정답/해설 포함)
+    quiz = (
+        supabase.table("quizzes")
+        .select("id, title, \"questions\":quiz_questions(id, order_num, content, options, answer, explanation)")
+        .eq("id", quiz_id)
+        .maybe_single()
+        .execute()
+    )
+
+    # 학생의 답안 조회
+    answers = (
+        supabase.table("quiz_submission_answers")
+        .select("question_id, selected_option, is_correct")
+        .eq("submission_id", submission_id)
+        .execute()
+    )
+    ans_map = {a["question_id"]: a for a in (answers.data or [])}
+
+    # 결과 조립
+    questions_result = []
+    for q in (quiz.data.get("questions") or []):
+        ans = ans_map.get(q["id"], {})
+        questions_result.append({
+            "id": q["id"],
+            "orderNum": q["order_num"],
+            "content": q["content"],
+            "options": q["options"],
+            "answer": q["answer"],
+            "explanation": q.get("explanation"),
+            "selectedOption": ans.get("selected_option"),
+            "isCorrect": ans.get("is_correct", False)
+        })
+
+    return {
+        "quizId": quiz.data["id"],
+        "title": quiz.data["title"],
+        "score": sub.data["score"],
+        "correctCount": sub.data["correct_count"],
+        "totalCount": sub.data["total_count"],
+        "submittedAt": sub.data["submitted_at"],
+        "questions": sorted(questions_result, key=lambda x: x["orderNum"])
+    }
+
+
 @router.post("/{quiz_id}/submissions", status_code=201)
 def submit_quiz(
     course_id: str,

--- a/backend/tests/test_quiz_detail.py
+++ b/backend/tests/test_quiz_detail.py
@@ -1,0 +1,82 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+from app.main import app
+from app.core.auth import get_current_user
+
+client = TestClient(app)
+
+def test_get_my_submission_success():
+    """학생 본인의 퀴즈 제출 상세 내역 조회 성공 케이스"""
+    mock_sb = MagicMock()
+    
+    # Auth Mock
+    mock_user = {"id": "student-abc", "role": "STUDENT", "email": "student@example.com"}
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+
+    # 1. 제출 내역 (quiz_submissions)
+    mock_sub = MagicMock()
+    mock_sub.data = {
+        "id": "sub-123",
+        "quiz_id": "quiz-001",
+        "student_id": "student-abc",
+        "score": 85.0,
+        "correct_count": 2,
+        "total_count": 3,
+        "submitted_at": "2026-04-13T10:00:00Z"
+    }
+    mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value = mock_sub
+
+    # 2. 퀴즈 및 문항 (quizzes)
+    mock_quiz = MagicMock()
+    mock_quiz.data = {
+        "id": "quiz-001",
+        "title": "테스트 퀴즈",
+        "questions": [
+            {"id": "q1", "order_num": 1, "content": "문제1", "options": ["A", "B"], "answer": "A", "explanation": "해설1"},
+            {"id": "q2", "order_num": 2, "content": "문제2", "options": ["C", "D"], "answer": "C", "explanation": "해설2"},
+            {"id": "q3", "order_num": 3, "content": "문제3", "options": ["E", "F"], "answer": "E", "explanation": "해설3"}
+        ]
+    }
+    mock_sb.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = mock_quiz
+
+    # 3. 학생 답안 (quiz_submission_answers)
+    mock_ans = MagicMock()
+    mock_ans.data = [
+        {"question_id": "q1", "selected_option": "A", "is_correct": True},
+        {"question_id": "q2", "selected_option": "D", "is_correct": False},
+        {"question_id": "q3", "selected_option": "E", "is_correct": True}
+    ]
+    mock_sb.table.return_value.select.return_value.eq.return_value.execute.return_value = mock_ans
+
+    with patch("app.routers.quiz.supabase", mock_sb):
+        response = client.get("/api/courses/course-001/quizzes/quiz-001/submissions/me")
+        
+    assert response.status_code == 200
+    data = response.json()
+    assert data["quizId"] == "quiz-001"
+    assert data["score"] == 85.0
+    assert len(data["questions"]) == 3
+    assert data["questions"][0]["isCorrect"] is True
+    assert data["questions"][1]["isCorrect"] is False
+    assert data["questions"][1]["selectedOption"] == "D"
+    assert data["questions"][1]["answer"] == "C"
+    assert data["questions"][1]["explanation"] == "해설2"
+    
+    app.dependency_overrides.clear()
+
+def test_get_my_submission_not_found():
+    """제출 내역이 없는 경우 404 반환"""
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value = MagicMock(data=None)
+
+    mock_user = {"id": "student-abc", "role": "STUDENT"}
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+
+    with patch("app.routers.quiz.supabase", mock_sb):
+        response = client.get("/api/courses/course-001/quizzes/quiz-001/submissions/me")
+    
+    assert response.status_code == 404
+    assert response.json()["message"] == "제출 내역이 없습니다."
+    
+    app.dependency_overrides.clear()

--- a/frontend/components/materials/teacher-materials.tsx
+++ b/frontend/components/materials/teacher-materials.tsx
@@ -63,6 +63,8 @@ import {
   getPostAnalyses,
   triggerStructureAnalysis,
   triggerConceptsAnalysis,
+  distributePreviewGuide,
+  distributeReviewSummary,
   type CourseScriptListItem,
   type PreviewGuide,
   type ReviewSummary,
@@ -130,8 +132,9 @@ export function TeacherMaterials() {
     audioId: string | null;
     fileName: string;
     transcript: string | null;
+    segments: Array<{ start: number; end: number; text: string }> | null;
     loading: boolean;
-  }>({ open: false, audioId: null, fileName: "", transcript: null, loading: false });
+  }>({ open: false, audioId: null, fileName: "", transcript: null, segments: null, loading: false });
 
   const [isStartingConvert, setIsStartingConvert] = useState(false);
   const [isUploadingScript, setIsUploadingScript] = useState(false);
@@ -145,6 +148,15 @@ export function TeacherMaterials() {
     loading: boolean;
     triggering: string | null;
   }>({ open: false, scriptId: null, scriptTitle: "", analyses: [], loading: false, triggering: null });
+
+  const [distModal, setDistModal] = useState<{
+    open: boolean;
+    materialType: "preview" | "review" | null;
+    sourceId: string | null;
+    targetLms: string;
+    section: string;
+    loading: boolean;
+  }>({ open: false, materialType: null, sourceId: null, targetLms: "MOODLE", section: "", loading: false });
 
   // 사전 분석 리포트 상태 (4.2/4.3 - logic/terminology/prerequisites + suggestions + report)
   const [scriptReportSheet, setScriptReportSheet] = useState<{
@@ -398,13 +410,19 @@ export function TeacherMaterials() {
   };
 
   const handleOpenTranscript = async (audio: AudioItem) => {
-    setTranscriptSheet({ open: true, audioId: audio.audioId, fileName: audio.fileName, transcript: null, loading: true });
+    setTranscriptSheet({ open: true, audioId: audio.audioId, fileName: audio.fileName, transcript: null, segments: null, loading: true });
     try {
       const data = await getAudioConvertTask(courseId!, audio.audioId);
-      setTranscriptSheet(prev => ({ ...prev, transcript: data.transcript ?? null, loading: false }));
+      setTranscriptSheet(prev => ({ ...prev, transcript: data.transcript ?? null, segments: data.segments ?? null, loading: false }));
     } catch {
       setTranscriptSheet(prev => ({ ...prev, loading: false }));
     }
+  };
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
   };
 
   const handleTriggerAnalysis = async (type: "structure" | "concepts") => {
@@ -419,6 +437,25 @@ export function TeacherMaterials() {
       setPostAnalysisSheet(prev => ({ ...prev, analyses: data.postAnalyses, triggering: null }));
     } catch {
       setPostAnalysisSheet(prev => ({ ...prev, triggering: null }));
+    }
+  };
+
+  const handleDistribute = async () => {
+    const { materialType, sourceId, targetLms, section } = distModal;
+    if (!courseId || !materialType || !sourceId) return;
+
+    setDistModal(prev => ({ ...prev, loading: true }));
+    try {
+      if (materialType === "preview") {
+        await distributePreviewGuide(courseId, sourceId, { targetLms, section });
+      } else {
+        await distributeReviewSummary(courseId, sourceId, { targetLms, section });
+      }
+      alert("LMS 배포가 시작되었습니다.");
+      setDistModal(prev => ({ ...prev, open: false, loading: false }));
+    } catch (e: any) {
+      alert(`배포 실패: ${e.message}`);
+      setDistModal(prev => ({ ...prev, loading: false }));
     }
   };
 
@@ -497,6 +534,11 @@ export function TeacherMaterials() {
                       <p className="text-xs text-muted-foreground">업데이트: {new Date(s.preview!.createdAt).toLocaleDateString()}</p>
                     </div>
                   </div>
+                  {s.preview!.status === "completed" && (
+                    <Button size="sm" variant="outline" onClick={() => setDistModal({ open: true, materialType: "preview", sourceId: s.preview!.previewGuideId, targetLms: "MOODLE", section: `week${s.weekNumber}`, loading: false })}>
+                      LMS 배포
+                    </Button>
+                  )}
                 </div>
               </Card>
             ))}
@@ -519,6 +561,11 @@ export function TeacherMaterials() {
                       <p className="text-xs text-muted-foreground">업데이트: {new Date(s.review!.createdAt).toLocaleDateString()}</p>
                     </div>
                   </div>
+                  {s.review!.status === "completed" && (
+                    <Button size="sm" variant="outline" onClick={() => setDistModal({ open: true, materialType: "review", sourceId: s.review!.reviewSummaryId, targetLms: "MOODLE", section: `week${s.weekNumber}`, loading: false })}>
+                      LMS 배포
+                    </Button>
+                  )}
                 </div>
               </Card>
             ))}
@@ -626,7 +673,26 @@ export function TeacherMaterials() {
       <Sheet open={transcriptSheet.open} onOpenChange={o => setTranscriptSheet(prev => ({ ...prev, open: o }))}>
         <SheetContent side="bottom" className="h-[80vh] overflow-y-auto">
           <SheetHeader><SheetTitle>음성 트랜스크립트</SheetTitle></SheetHeader>
-          {transcriptSheet.loading ? <div className="flex justify-center py-12"><Loader2 className="animate-spin" /></div> : <p className="whitespace-pre-wrap text-sm py-4">{transcriptSheet.transcript || "내용이 없습니다."}</p>}
+          {transcriptSheet.loading ? (
+            <div className="flex justify-center py-12"><Loader2 className="animate-spin" /></div>
+          ) : (
+            <div className="py-6 space-y-4">
+              {transcriptSheet.segments && transcriptSheet.segments.length > 0 ? (
+                <div className="flex flex-col gap-3">
+                  {transcriptSheet.segments.map((seg, i) => (
+                    <div key={i} className="flex gap-4 p-2 rounded-lg hover:bg-muted/50 transition-colors group">
+                      <span className="text-xs font-mono text-primary bg-primary/10 px-2 py-1 rounded shrink-0 self-start">
+                        {formatTime(seg.start)}
+                      </span>
+                      <p className="text-sm leading-relaxed text-foreground">{seg.text}</p>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="whitespace-pre-wrap text-sm text-muted-foreground">{transcriptSheet.transcript || "내용이 없습니다."}</p>
+              )}
+            </div>
+          )}
         </SheetContent>
       </Sheet>
 
@@ -661,6 +727,41 @@ export function TeacherMaterials() {
           )}
         </SheetContent>
       </Sheet>
+
+      <Dialog open={distModal.open} onOpenChange={o => setDistModal(prev => ({ ...prev, open: o }))}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>LMS 배포</DialogTitle>
+            <DialogDescription>
+              {distModal.materialType === "preview" ? "예습 가이드" : "복습 요약본"}를 LMS에 업로드합니다.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label>LMS 유형</Label>
+              <Select value={distModal.targetLms} onValueChange={v => setDistModal(prev => ({ ...prev, targetLms: v }))}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="MOODLE">Moodle</SelectItem>
+                  <SelectItem value="CANVAS">Canvas</SelectItem>
+                  <SelectItem value="BLACKBOARD">Blackboard</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>LMS 섹션 (주차 등)</Label>
+              <Input value={distModal.section} onChange={e => setDistModal(prev => ({ ...prev, section: e.target.value }))} placeholder="예: week4" />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDistModal(prev => ({ ...prev, open: false }))}>취소</Button>
+            <Button onClick={handleDistribute} disabled={distModal.loading}>
+              {distModal.loading ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+              업로드 시작
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/components/quiz/student-quiz.tsx
+++ b/frontend/components/quiz/student-quiz.tsx
@@ -16,14 +16,23 @@ import {
   Award,
   Target,
   Loader2,
+  Check,
+  X,
 } from "lucide-react";
 import {
   getCourses,
   getCourseQuizzes,
   getStudentQuizHistory,
+  getStudentQuizSubmissionDetail,
   type Quiz,
   type QuizSubmissionHistory,
 } from "@/lib/api";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { useAuth } from "@/contexts/auth-context";
 
 export function StudentQuiz() {
@@ -33,6 +42,12 @@ export function StudentQuiz() {
   const [completedQuizzes, setCompletedQuizzes] = useState<QuizSubmissionHistory[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [detailSheet, setDetailSheet] = useState<{
+    open: boolean;
+    loading: boolean;
+    data: any | null;
+  }>({ open: false, loading: false, data: null });
 
   useEffect(() => {
     if (!user?.id) return;
@@ -90,6 +105,17 @@ export function StudentQuiz() {
   const maxScore = completedQuizzes.length > 0
     ? Math.max(...completedQuizzes.map((q) => q.score))
     : 0;
+
+  const handleOpenDetail = async (courseId: string, quizId: string) => {
+    setDetailSheet({ open: true, loading: true, data: null });
+    try {
+      const data = await getStudentQuizSubmissionDetail(courseId, quizId);
+      setDetailSheet({ open: true, loading: false, data });
+    } catch (err) {
+      console.error(err);
+      setDetailSheet({ open: true, loading: false, data: null });
+    }
+  };
 
   if (isLoading) {
     return (
@@ -292,7 +318,7 @@ export function StudentQuiz() {
                       <Button size="sm" variant="outline" className="flex-1">
                         {"오답 복습"}
                       </Button>
-                      <Button size="sm" variant="ghost">
+                      <Button size="sm" variant="ghost" onClick={() => handleOpenDetail(quiz.courseId, quiz.quizId)}>
                         {"상세 결과"}
                       </Button>
                     </div>
@@ -303,6 +329,84 @@ export function StudentQuiz() {
           )}
         </TabsContent>
       </Tabs>
+
+      <Sheet open={detailSheet.open} onOpenChange={o => setDetailSheet(prev => ({ ...prev, open: o }))}>
+        <SheetContent side="bottom" className="h-[90vh] overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>퀴즈 상세 결과</SheetTitle>
+          </SheetHeader>
+          {detailSheet.loading ? (
+            <div className="flex justify-center py-12"><Loader2 className="size-8 animate-spin text-primary" /></div>
+          ) : !detailSheet.data ? (
+            <div className="py-8 text-center text-muted-foreground">결과를 불러올 수 없습니다.</div>
+          ) : (
+            <div className="flex flex-col gap-6 py-6">
+              <div className="flex items-center justify-between rounded-xl bg-primary/5 p-4">
+                <div>
+                  <h3 className="text-lg font-bold">{detailSheet.data.title}</h3>
+                  <p className="text-sm text-muted-foreground">{new Date(detailSheet.data.submittedAt).toLocaleString()}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-3xl font-bold text-primary">{Math.round(detailSheet.data.score)}점</p>
+                  <p className="text-sm text-muted-foreground">{detailSheet.data.correctCount}/{detailSheet.data.totalCount} 맞춤</p>
+                </div>
+              </div>
+
+              <div className="space-y-6">
+                {detailSheet.data.questions.map((q: any, i: number) => (
+                  <div key={q.id} className="space-y-3">
+                    <div className="flex items-start gap-3">
+                      <div className={`mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full text-white ${q.isCorrect ? "bg-emerald-500" : "bg-destructive"}`}>
+                        {q.isCorrect ? <Check className="size-4" /> : <X className="size-4" />}
+                      </div>
+                      <div className="flex-1">
+                        <p className="font-medium">
+                          <span className="mr-2 text-muted-foreground">{i + 1}.</span>
+                          {q.content}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="ml-9 grid gap-2">
+                      {q.options.map((opt: string) => {
+                        const isSelected = q.selectedOption === opt;
+                        const isCorrect = q.answer === opt;
+                        return (
+                          <div
+                            key={opt}
+                            className={`rounded-lg border p-3 text-sm transition-colors ${
+                              isCorrect
+                                ? "border-emerald-500 bg-emerald-500/10 text-emerald-700"
+                                : isSelected
+                                ? "border-destructive bg-destructive/10 text-destructive-700"
+                                : "border-border bg-card"
+                            }`}
+                          >
+                            <div className="flex items-center justify-between">
+                              <span>{opt}</span>
+                              {isCorrect && <CheckCircle className="size-4 text-emerald-500" />}
+                              {!isCorrect && isSelected && <AlertTriangle className="size-4 text-destructive" />}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+
+                    {q.explanation && (
+                      <div className="ml-9 rounded-lg bg-muted p-3 text-xs text-muted-foreground">
+                        <p className="mb-1 font-semibold text-foreground flex items-center gap-1">
+                          <BookOpen className="size-3" /> 해설
+                        </p>
+                        {q.explanation}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -602,6 +602,49 @@ export async function syncLmsStudents(
   });
 }
 
+// 6.4 LMS Distributions
+export async function distributePreviewGuide(
+  courseId: string,
+  guideId: string,
+  payload: { targetLms: string; section?: string },
+) {
+  return request<{ distributionId: string; lmsUrl: string; message: string }>(
+    `/api/courses/${courseId}/preview-guides/${guideId}/distributions`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export async function distributeReviewSummary(
+  courseId: string,
+  summaryId: string,
+  payload: { targetLms: string; section?: string },
+) {
+  return request<{ distributionId: string; lmsUrl: string; message: string }>(
+    `/api/courses/${courseId}/review-summaries/${summaryId}/distributions`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export async function distributeAnnouncement(
+  courseId: string,
+  announcementId: string,
+  payload: { targetLms: string; section?: string },
+) {
+  return request<{ distributionId: string; lmsUrl: string; message: string }>(
+    `/api/courses/${courseId}/announcements/${announcementId}/distributions`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
 export async function getNoticeSettings() {
   return request<NoticeSettings>("/api/notices/settings");
 }
@@ -699,6 +742,7 @@ export async function getAudioConvertTask(courseId: string, audioId: string) {
     audioId: res.audioId,
     status: res.status,
     transcript: res.transcript,
+    segments: res.segments as Array<{ start: number; end: number; text: string }> | undefined,
     transcriptPreview: res.transcript ? res.transcript.substring(0, 200) : null,
     completedAt: res.transcriptCompletedAt,
     fileName: res.fileName,
@@ -782,6 +826,30 @@ export async function getStudentQuizHistory(courseId?: string): Promise<{
   }>(
     `/api/dashboard/students/quiz-history${params.toString() ? `?${params}` : ""}`,
   );
+}
+
+export async function getStudentQuizSubmissionDetail(
+  courseId: string,
+  quizId: string,
+) {
+  return request<{
+    quizId: string;
+    title: string;
+    score: number;
+    correctCount: number;
+    totalCount: number;
+    submittedAt: string;
+    questions: Array<{
+      id: string;
+      orderNum: number;
+      content: string;
+      options: string[];
+      answer: string;
+      explanation: string | null;
+      selectedOption: string | null;
+      isCorrect: boolean;
+    }>;
+  }>(`/api/courses/${courseId}/quizzes/${quizId}/submissions/me`);
 }
 
 export async function getStudentMaterials(courseId?: string): Promise<{


### PR DESCRIPTION

## 🚀 변경 사항
  주요 작업 내역

   1. LMS 배포 UI (기능 6.4)
       * Frontend API: distributePreviewGuide, distributeReviewSummary 등 LMS 배포를 위한 API 호출 함수를 api.ts에 추가했습니다.
       * Teacher Materials: 교수자용 자료 관리 화면(teacher-materials.tsx)의 예습/복습 탭에 "LMS 배포" 버튼을 추가했습니다.
       * Distribution Modal: 배포 시 대상 LMS(Moodle, Canvas, Blackboard)와 섹션(주차)을 선택할 수 있는 다이얼로그를 구현하여 배포
         프로세스를 완성했습니다.

   2. 퀴즈 응시 결과 상세 뷰 (기능 5.3)
       * Backend API: 학생이 본인의 퀴즈 제출 상세 내역(문항, 선택한 답, 정답, 해설 포함)을 조회할 수 있는 GET
         /api/courses/{id}/quizzes/{id}/submissions/me 엔드포인트를 quiz.py에 신규 구현했습니다.
       * Student Quiz: 학생용 퀴즈 화면(student-quiz.tsx)의 '완료' 탭에 "상세 결과" 버튼을 활성화했습니다.
       * Detailed Result Sheet: 버튼 클릭 시 각 문항별 정오답 여부, 학생의 선택지, 정답 및 AI가 생성한 상세 해설을 시각적으로
         확인할 수 있는 상세 뷰를 구축했습니다.

   3. 오디오 트랜스크립트 뷰어 개선 (기능 6.5)
       * Frontend API: getAudioConvertTask가 백엔드에서 생성된 시간대별 세그먼트(segments) 데이터를 포함하여 반환하도록 타입을
         수정했습니다.
       * Rich Viewer: 기존의 단순 텍스트 표시 방식에서 벗어나, [00:00 - 00:05]와 같이 타임스탬프와 함께 구간별 텍스트를 보여주는
         리치 뷰어 컴포넌트를 teacher-materials.tsx에 적용했습니다.
---


## 이슈 연결
<!--
PR merge 시 이슈가 자동으로 닫히도록 설정합니다.
-->
Closes #116 

---

## 📸 스크린샷
<!--
필수 항목입니다.
변경 전 / 변경 후 또는 데스크탑 / 모바일 스크린샷을 첨부합니다.
GIF도 가능하며, 인터랙션이 있는 경우 우선 첨부합니다.
-->

---

## 🧪 체크리스트
<!--
PR 생성 전 반드시 확인합니다.
-->
- [ ] 스크린샷 또는 GIF 첨부
- [ ] 로컬 환경에서 정상 작동 확인
- [ ] 주요 기능 테스트 완료
- [ ] 관련 없는 파일 변경 없음

---

## 참고 사항
<!--
리뷰 시 참고할 맥락이나 추후 개선 포인트를 작성합니다.
-->
